### PR TITLE
Support width/length gutters

### DIFF
--- a/app.js
+++ b/app.js
@@ -75,8 +75,9 @@ document.addEventListener('DOMContentLoaded', () => {
             button.type = 'button';
             button.className = `${type}-size-button`;
             if (type === 'gutter') {
-                button.textContent = option.gutter;
-                button.dataset.gutter = option.gutter;
+                button.textContent = `${option.width} x ${option.length}`;
+                button.dataset.width = option.width;
+                button.dataset.length = option.length;
             } else {
                 button.textContent = `${option.width} x ${option.length}`;
                 button.dataset.width = option.width;
@@ -129,8 +130,8 @@ document.addEventListener('DOMContentLoaded', () => {
             if (!isCustom) {
                 // Set input values from button data
                 if (type === 'gutter') {
-                    elements.gutterWidth.value = event.target.dataset.gutter;
-                    elements.gutterLength.value = event.target.dataset.gutter;
+                    elements.gutterWidth.value = event.target.dataset.width;
+                    elements.gutterLength.value = event.target.dataset.length;
                 } else {
                     elements[`${type}Width`].value = event.target.dataset.width;
                     elements[`${type}Length`].value = event.target.dataset.length;
@@ -260,7 +261,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const defaultSelections = {
             sheet: '12 x 18',
             doc: '3.5 x 2',
-            gutter: '0.125'
+            gutter: '0.125 x 0.125'
         };
 
         Object.entries(defaultSelections).forEach(([type, value]) => {
@@ -271,8 +272,9 @@ document.addEventListener('DOMContentLoaded', () => {
             } else {
                 // If the default button is not found, set the input values directly
                 if (type === 'gutter') {
-                    elements.gutterWidth.value = value;
-                    elements.gutterLength.value = value;
+                    const [width, length] = value.split(' x ');
+                    elements.gutterWidth.value = width;
+                    elements.gutterLength.value = length;
                 } else {
                     const [width, length] = value.split(' x ');
                     elements[`${type}Width`].value = width;

--- a/sizeOptions.js
+++ b/sizeOptions.js
@@ -20,9 +20,8 @@ export const SIZE_OPTIONS = {
         { width: 9, length: 12, name: "Rich People Letterhead" },
         { width: 11, length: 17, name: "Tabloid" }
     ],
-    // TODO: make the gutter options like the others with width and length (check the app.js to update the relevant code)
     gutter: [
-        { gutter: 0.125 },
-        { gutter: 0.25 }
+        { width: 0.125, length: 0.125 },
+        { width: 0.25, length: 0.25 }
     ]
 };


### PR DESCRIPTION
## Summary
- store gutter sizes using `{ width, length }`
- set gutter button dataset attributes for width and length
- update default size selection to account for new format

## Testing
- `node tests/calculations.test.js && node tests/calculateAdaptiveScale.test.js`


------
https://chatgpt.com/codex/tasks/task_e_687c6ac52b04832480bc8e1474697d79