### PR TITLE
Refactor scoring into its own module

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,7 +2,8 @@
 
 // Import the drawLayout function from the visualizer module
 import { drawLayout } from './visualizer.js';
-import { calculateLayoutDetails as calcDetails, calculateSequence as calcSequence, calculateScorePositions } from './calculations.js';
+import { calculateLayoutDetails as calcDetails, calculateSequence as calcSequence } from './calculations.js';
+import { calculateScorePositions } from './scoring.js';
 
 // Import the SIZE_OPTIONS object from the sizeOptions module
 import { SIZE_OPTIONS } from './sizeOptions.js';

--- a/calculations.js
+++ b/calculations.js
@@ -48,25 +48,3 @@ export function calculateSequence(layout) {
     return sequence;
 }
 
-export function calculateScorePositions(layout, { foldType = 'bifold', scoredWithMargins = false } = {}) {
-    const marginOffset = scoredWithMargins ? layout.topMargin : 0;
-    let scorePositions = [];
-    for (let i = 0; i < layout.docsDown; i++) {
-        if (foldType === 'bifold') {
-            scorePositions.push({
-                y: (layout.docLength / 2) + i * (layout.docLength + layout.gutterLength) + marginOffset,
-                scoredWithMargins
-            });
-        } else if (foldType === 'trifold') {
-            scorePositions.push({
-                y: (layout.docLength / 3) + i * (layout.docLength + layout.gutterLength) + marginOffset,
-                scoredWithMargins
-            });
-            scorePositions.push({
-                y: (2 * layout.docLength / 3) - 0.05 + i * (layout.docLength + layout.gutterLength) + marginOffset,
-                scoredWithMargins
-            });
-        }
-    }
-    return scorePositions;
-}

--- a/scoring.js
+++ b/scoring.js
@@ -1,0 +1,26 @@
+// scoring.js
+// Functions related to scoring positions and other scoring utilities
+
+export function calculateScorePositions(layout, { foldType = 'bifold', scoredWithMargins = false } = {}) {
+    const marginOffset = scoredWithMargins ? layout.topMargin : 0;
+    let scorePositions = [];
+    for (let i = 0; i < layout.docsDown; i++) {
+        if (foldType === 'bifold') {
+            scorePositions.push({
+                y: (layout.docLength / 2) + i * (layout.docLength + layout.gutterLength) + marginOffset,
+                scoredWithMargins
+            });
+        } else if (foldType === 'trifold') {
+            scorePositions.push({
+                y: (layout.docLength / 3) + i * (layout.docLength + layout.gutterLength) + marginOffset,
+                scoredWithMargins
+            });
+            scorePositions.push({
+                y: (2 * layout.docLength / 3) - 0.05 + i * (layout.docLength + layout.gutterLength) + marginOffset,
+                scoredWithMargins
+            });
+        }
+    }
+    return scorePositions;
+}
+

--- a/tests/calculations.test.js
+++ b/tests/calculations.test.js
@@ -1,7 +1,7 @@
 const assert = require('assert');
 
 (async () => {
-  const { calculateLayoutDetails, calculateSequence, calculateScorePositions } = await import('../calculations.js');
+  const { calculateLayoutDetails, calculateSequence } = await import('../calculations.js');
 
   const layout = calculateLayoutDetails({
     sheetWidth: 12,
@@ -29,15 +29,6 @@ const assert = require('assert');
   const sequence = calculateSequence(layout);
   assert.deepStrictEqual(sequence, expectedSequence, 'Sequence calculation incorrect');
 
-  // Verify bifold score positions with margins
-  const bifoldScores = calculateScorePositions(layout, { foldType: 'bifold', scoredWithMargins: true });
-  assert.strictEqual(bifoldScores.length, 4, 'Bifold score count incorrect');
-  assert.strictEqual(bifoldScores[0].y, 2.625, 'First bifold score incorrect');
-
-  // Verify trifold score positions without margins
-  const trifoldScores = calculateScorePositions(layout, { foldType: 'trifold', scoredWithMargins: false });
-  assert.strictEqual(trifoldScores.length, 8, 'Trifold score count incorrect');
-  assert.ok(Math.abs(trifoldScores[0].y - 1.3333333333333333) < 1e-9, 'First trifold score incorrect');
 
   console.log('All calculations tests passed');
 })();

--- a/tests/scoring.test.js
+++ b/tests/scoring.test.js
@@ -1,0 +1,27 @@
+const assert = require('assert');
+
+(async () => {
+  const { calculateLayoutDetails } = await import('../calculations.js');
+  const { calculateScorePositions } = await import('../scoring.js');
+
+  const layout = calculateLayoutDetails({
+    sheetWidth: 12,
+    sheetLength: 18,
+    docWidth: 3,
+    docLength: 4,
+    gutterWidth: 0.5,
+    gutterLength: 0.25
+  });
+
+  // Verify bifold score positions with margins
+  const bifoldScores = calculateScorePositions(layout, { foldType: 'bifold', scoredWithMargins: true });
+  assert.strictEqual(bifoldScores.length, 4, 'Bifold score count incorrect');
+  assert.strictEqual(bifoldScores[0].y, 2.625, 'First bifold score incorrect');
+
+  // Verify trifold score positions without margins
+  const trifoldScores = calculateScorePositions(layout, { foldType: 'trifold', scoredWithMargins: false });
+  assert.strictEqual(trifoldScores.length, 8, 'Trifold score count incorrect');
+  assert.ok(Math.abs(trifoldScores[0].y - 1.3333333333333333) < 1e-9, 'First trifold score incorrect');
+
+  console.log('All scoring tests passed');
+})();


### PR DESCRIPTION
## Summary
- move score position helpers to `scoring.js`
- adjust `calculations.js` to only export layout and sequence functions
- import `calculateScorePositions` from new scoring module in the app
- update tests to match new module structure and add scoring tests

## Testing
- `node tests/calculations.test.js`
- `node tests/scoring.test.js`
- `node tests/calculateAdaptiveScale.test.js`


------
https://chatgpt.com/codex/tasks/task_e_687c6c1174d483248ca4b5b71a17fed8