### PR TITLE
Refine label scaling

### DIFF
--- a/style.css
+++ b/style.css
@@ -9,6 +9,16 @@
     --bg-color: #c0c0c0;
     --primary-color: #000080;
     --font-family: 'Tahoma', 'Verdana', sans-serif;
+    /* Canvas drawing variables */
+    --canvas-sheet-color: #000;
+    --canvas-margin-color: red;
+    --canvas-score-color: magenta;
+    --canvas-label-color: blue;
+    --canvas-font-family: Arial, sans-serif;
+    /* Minimum font size in pixels for canvas text */
+    --canvas-font-size: 12;
+    /* Percentage of the document box used for label text */
+    --canvas-label-scale: 0.2;
 }
 
 /* General Styles */

--- a/visualizer.js
+++ b/visualizer.js
@@ -18,9 +18,11 @@ export function calculateAdaptiveScale(layout, canvasWidth, canvasHeight) {
 }
 
 // Draw document labels on the canvas
-export function drawDocumentLabels(ctx, layout, scale, offsetX, offsetY) {
-    ctx.font = '12px Arial';
-    ctx.fillStyle = 'blue';
+export function drawDocumentLabels(ctx, layout, scale, offsetX, offsetY, styles) {
+    const docSize = Math.min(layout.docWidth, layout.docLength) * scale;
+    const fontSize = Math.max(styles.baseFontSize, docSize * styles.labelScale);
+    ctx.font = `${fontSize}px ${styles.fontFamily}`;
+    ctx.fillStyle = styles.labelColor;
     ctx.textAlign = 'center';
     ctx.textBaseline = 'middle';
 
@@ -38,6 +40,18 @@ export function drawDocumentLabels(ctx, layout, scale, offsetX, offsetY) {
 // Draw the layout on the canvas
 export function drawLayout(canvas, layout, scorePositions = []) {
     const ctx = canvas.getContext('2d');
+
+    // Get drawing styles from CSS variables
+    const rootStyle = getComputedStyle(document.documentElement);
+    const styles = {
+        sheetColor: rootStyle.getPropertyValue('--canvas-sheet-color').trim() || 'black',
+        marginColor: rootStyle.getPropertyValue('--canvas-margin-color').trim() || 'red',
+        scoreColor: rootStyle.getPropertyValue('--canvas-score-color').trim() || 'magenta',
+        labelColor: rootStyle.getPropertyValue('--canvas-label-color').trim() || 'blue',
+        fontFamily: rootStyle.getPropertyValue('--canvas-font-family').trim() || 'Arial',
+        baseFontSize: parseFloat(rootStyle.getPropertyValue('--canvas-font-size')) || 12,
+        labelScale: parseFloat(rootStyle.getPropertyValue('--canvas-label-scale')) || 0.2
+    };
     
     // Set canvas size to match its display size
     canvas.width = canvas.offsetWidth;
@@ -60,7 +74,7 @@ export function drawLayout(canvas, layout, scorePositions = []) {
     ctx.translate(0.5, 0.5);
 
     // Draw sheet
-    ctx.strokeStyle = 'black';
+    ctx.strokeStyle = styles.sheetColor;
     ctx.strokeRect(
         Math.round(offsetX),
         Math.round(offsetY),
@@ -83,7 +97,7 @@ export function drawLayout(canvas, layout, scorePositions = []) {
     }
 
     // Draw margins
-    ctx.strokeStyle = 'red';
+    ctx.strokeStyle = styles.marginColor;
     ctx.strokeRect(
         Math.round(offsetX + layout.leftMargin * scale),
         Math.round(offsetY + layout.topMargin * scale),
@@ -94,7 +108,7 @@ export function drawLayout(canvas, layout, scorePositions = []) {
     // Draw score lines
     // TODO: Add support for different gutter width or length values in calculating the score positions
     if (scorePositions.length > 0) {
-        ctx.strokeStyle = 'magenta';
+        ctx.strokeStyle = styles.scoreColor;
         ctx.setLineDash([5, 5]);
         scorePositions.forEach(pos => {
             // Adjust y position based on whether margins are included
@@ -109,5 +123,5 @@ export function drawLayout(canvas, layout, scorePositions = []) {
 
     ctx.translate(-0.5, -0.5);
     // Draw document labels
-    drawDocumentLabels(ctx, layout, scale, offsetX, offsetY);
+    drawDocumentLabels(ctx, layout, scale, offsetX, offsetY, styles);
 }


### PR DESCRIPTION
## Summary
- set CSS variable `--canvas-label-scale` to control font size relative to document dimensions
- compute label font size in `visualizer.js` using the new variable

## Testing
- `node tests/calculateAdaptiveScale.test.js && node tests/calculations.test.js && node tests/scoring.test.js`


------
https://chatgpt.com/codex/tasks/task_e_687d07df5c148324a6df9dbcc366210e