### PR TITLE
feat: add configurable sheet margin

### DIFF
--- a/app.js
+++ b/app.js
@@ -20,6 +20,7 @@ document.addEventListener('DOMContentLoaded', () => {
         sheetInputs: document.getElementById('sheetDimensionsInputs'),
         sheetWidth: document.getElementById('sheetWidth'),
         sheetLength: document.getElementById('sheetLength'),
+        sheetMargin: document.getElementById('sheetMargin'),
         
         // Document elements
         docButtons: document.getElementById('docButtonsContainer'),
@@ -82,6 +83,7 @@ document.addEventListener('DOMContentLoaded', () => {
         elements.scoreButton.addEventListener('click', showScoreOptions);
         elements.miscDataButton.addEventListener('click', toggleMiscData);
         elements.calculateScoresButton.addEventListener('click', calculateScores);
+        elements.sheetMargin.addEventListener('input', calculateLayout);
     }
 
     // ===== Event Handlers =====
@@ -150,6 +152,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const docLength = parseFloat(elements.docLength.value);
         const gutterWidth = parseFloat(elements.gutterWidth.value);
         const gutterLength = parseFloat(elements.gutterLength.value);
+        const sheetMargin = parseFloat(elements.sheetMargin.value);
 
         return calcDetails({
             sheetWidth,
@@ -157,7 +160,8 @@ document.addEventListener('DOMContentLoaded', () => {
             docWidth,
             docLength,
             gutterWidth,
-            gutterLength
+            gutterLength,
+            sheetMargin
         });
     }
 
@@ -193,6 +197,7 @@ document.addEventListener('DOMContentLoaded', () => {
         elements.docLength.value = "2.0";
         elements.gutterWidth.value = "0.125";
         elements.gutterLength.value = "0.125";
+        elements.sheetMargin.value = "0.125";
     }
 
     // Function to select default sizes for sheet, doc, and gutter

--- a/calculations.js
+++ b/calculations.js
@@ -1,14 +1,19 @@
-export function calculateLayoutDetails({ sheetWidth, sheetLength, docWidth, docLength, gutterWidth, gutterLength }) {
-    const docsAcross = Math.floor(sheetWidth / (docWidth + gutterWidth));
-    const docsDown = Math.floor(sheetLength / (docLength + gutterLength));
+export function calculateLayoutDetails({ sheetWidth, sheetLength, docWidth, docLength, gutterWidth, gutterLength, sheetMargin = 0.125 }) {
+    const usableWidth = Math.max(0, sheetWidth - 2 * sheetMargin);
+    const usableLength = Math.max(0, sheetLength - 2 * sheetMargin);
+
+    const docsAcross = Math.floor(usableWidth / (docWidth + gutterWidth));
+    const docsDown = Math.floor(usableLength / (docLength + gutterLength));
     const totalGutterWidth = (docsAcross - 1) * gutterWidth;
     const totalGutterLength = (docsDown - 1) * gutterLength;
     const imposedSpaceWidth = (docWidth * docsAcross) + totalGutterWidth;
     const imposedSpaceLength = (docLength * docsDown) + totalGutterLength;
     const gutterSpaceWidth = totalGutterWidth;
     const gutterSpaceLength = totalGutterLength;
-    const topMargin = (sheetLength - imposedSpaceLength) / 2;
-    const leftMargin = (sheetWidth - imposedSpaceWidth) / 2;
+
+    const topMargin = sheetMargin + (usableLength - imposedSpaceLength) / 2;
+    const leftMargin = sheetMargin + (usableWidth - imposedSpaceWidth) / 2;
+
     return {
         sheetWidth,
         sheetLength,
@@ -16,6 +21,9 @@ export function calculateLayoutDetails({ sheetWidth, sheetLength, docWidth, docL
         docLength,
         gutterWidth,
         gutterLength,
+        sheetMargin,
+        usableWidth,
+        usableLength,
         docsAcross,
         docsDown,
         imposedSpaceWidth,

--- a/display.js
+++ b/display.js
@@ -16,18 +16,23 @@ export function renderProgramSequence(sequence, container) {
 
 export function renderLayoutDetails(layout, container) {
     const nUp = layout.docsAcross * layout.docsDown;
-    const areaUsed = (layout.docWidth * layout.docLength * nUp) /
-        (layout.sheetWidth * layout.sheetLength);
+    const areaUsedFull = (layout.docWidth * layout.docLength * nUp) / (layout.sheetWidth * layout.sheetLength);
+    const areaUsedUsable = (layout.usableWidth > 0 && layout.usableLength > 0)
+        ? (layout.docWidth * layout.docLength * nUp) / (layout.usableWidth * layout.usableLength)
+        : 0;
     const html = `
         <h2>Layout Details</h2>
         <table>
             <tr><th>Sheet Size</th><td>${layout.sheetWidth} x ${layout.sheetLength} in</td></tr>
+            <tr><th>Usable Sheet Size</th><td>${layout.usableWidth.toFixed(2)} x ${layout.usableLength.toFixed(2)} in</td></tr>
             <tr><th>Document Size</th><td>${layout.docWidth} x ${layout.docLength} in</td></tr>
             <tr><th>Imposed Space Size</th><td>${layout.imposedSpaceWidth.toFixed(2)} x ${layout.imposedSpaceLength.toFixed(2)} in</td></tr>
             <tr><th>N-Up</th><td>${nUp} (${layout.docsAcross}x${layout.docsDown})</td></tr>
+            <tr><th>Sheet Margin</th><td>${layout.sheetMargin.toFixed(3)} in</td></tr>
             <tr><th>Top Margin</th><td>${layout.topMargin.toFixed(2)} in</td></tr>
             <tr><th>Left Margin</th><td>${layout.leftMargin.toFixed(2)} in</td></tr>
-            <tr><th>Coverage Percentage / Wasted Percentage</th><td>${(areaUsed * 100).toFixed(2)}% : ${(100 - areaUsed * 100).toFixed(2)}%</td></tr>
+            <tr><th>Coverage Percentage / Wasted Percentage</th><td>${(areaUsedFull * 100).toFixed(2)}% : ${(100 - areaUsedFull * 100).toFixed(2)}%</td></tr>
+            <tr><th>Coverage on Usable Sheet</th><td>${(areaUsedUsable * 100).toFixed(2)}%</td></tr>
             <tr><th>Doc Plus Gutter Size</th><td>${(layout.docWidth + layout.gutterWidth).toFixed(2)} x ${(layout.docLength + layout.gutterLength).toFixed(2)} in</td></tr>
         </table>
     `;

--- a/index.html
+++ b/index.html
@@ -20,6 +20,8 @@
                         <span>x</span>
                         <input type="number" id="sheetLength" name="sheetLength" step="0.25" value="18.0" aria-label="Sheet Length">
                     </div>
+                    <label for="sheetMargin">Sheet Margin (in):</label>
+                    <input type="number" id="sheetMargin" step="0.001" value="0.125">
                 </section>
 
                 <section class="dimensions-section">

--- a/scoring.js
+++ b/scoring.js
@@ -2,6 +2,7 @@
 // Functions related to scoring positions and other scoring utilities
 
 export function calculateScorePositions(layout, { foldType = 'bifold', scoredWithMargins = false } = {}) {
+    // layout.topMargin already includes any sheet margin
     const marginOffset = scoredWithMargins ? layout.topMargin : 0;
     let scorePositions = [];
     for (let i = 0; i < layout.docsDown; i++) {

--- a/tests/calculations.test.js
+++ b/tests/calculations.test.js
@@ -9,7 +9,8 @@ const assert = require('assert');
     docWidth: 3,
     docLength: 4,
     gutterWidth: 0.5,
-    gutterLength: 0.25
+    gutterLength: 0.25,
+    sheetMargin: 0.125
   });
 
   // Verify basic layout calculations
@@ -17,6 +18,9 @@ const assert = require('assert');
   assert.strictEqual(layout.docsDown, 4, 'docsDown incorrect');
   assert.strictEqual(layout.topMargin, 0.625, 'topMargin incorrect');
   assert.strictEqual(layout.leftMargin, 1, 'leftMargin incorrect');
+  assert.strictEqual(layout.sheetMargin, 0.125, 'sheetMargin incorrect');
+  assert.strictEqual(layout.usableWidth, 11.75, 'usableWidth incorrect');
+  assert.strictEqual(layout.usableLength, 17.75, 'usableLength incorrect');
 
   // Verify sequence calculation
   const expectedSequence = [
@@ -28,6 +32,19 @@ const assert = require('assert');
   ];
   const sequence = calculateSequence(layout);
   assert.deepStrictEqual(sequence, expectedSequence, 'Sequence calculation incorrect');
+
+  // Verify margin reduces available space
+  const marginLayout = calculateLayoutDetails({
+    sheetWidth: 8,
+    sheetLength: 10,
+    docWidth: 4,
+    docLength: 5,
+    gutterWidth: 0,
+    gutterLength: 0,
+    sheetMargin: 1
+  });
+  assert.strictEqual(marginLayout.docsAcross, 1, 'docsAcross with margin incorrect');
+  assert.strictEqual(marginLayout.docsDown, 1, 'docsDown with margin incorrect');
 
 
   console.log('All calculations tests passed');

--- a/tests/scoring.test.js
+++ b/tests/scoring.test.js
@@ -10,7 +10,8 @@ const assert = require('assert');
     docWidth: 3,
     docLength: 4,
     gutterWidth: 0.5,
-    gutterLength: 0.25
+    gutterLength: 0.25,
+    sheetMargin: 0.125
   });
 
   // Verify bifold score positions with margins

--- a/visualizer.js
+++ b/visualizer.js
@@ -68,6 +68,17 @@ export function drawLayout(canvas, layout, scorePositions = []) {
         Math.round(layout.sheetLength * scale)
     );
 
+    // Draw sheet margin boundary
+    if (layout.sheetMargin > 0) {
+        ctx.strokeStyle = 'orange';
+        ctx.strokeRect(
+            Math.round(offsetX + layout.sheetMargin * scale),
+            Math.round(offsetY + layout.sheetMargin * scale),
+            Math.round((layout.sheetWidth - 2 * layout.sheetMargin) * scale),
+            Math.round((layout.sheetLength - 2 * layout.sheetMargin) * scale)
+        );
+    }
+
     // Draw documents
     for (let i = 0; i < layout.docsAcross; i++) {
         for (let j = 0; j < layout.docsDown; j++) {


### PR DESCRIPTION
## Summary
- allow layout calculations to subtract a sheet margin before imposition, returning usable sheet dimensions
- render sheet margin input and visualize printable area separately from imposed region
- display margin values and usable sheet coverage, with updated tests

## Testing
- `node tests/calculations.test.js`
- `node tests/scoring.test.js`
- `node tests/calculateAdaptiveScale.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6894f528157c8324a034e401b6b6c2f6