### PR TITLE
Support sheet margins in layout calculations

### DIFF
--- a/app.js
+++ b/app.js
@@ -131,6 +131,9 @@ document.addEventListener('DOMContentLoaded', () => {
         const widthInput = elements[`${type}Width`];
         const lengthInput = elements[`${type}Length`];
         [widthInput.value, lengthInput.value] = [lengthInput.value, widthInput.value];
+        if (type === 'sheet') {
+            [elements.marginWidth.value, elements.marginLength.value] = [elements.marginLength.value, elements.marginWidth.value];
+        }
         if (shouldCalculate) {
             calculateLayout();
         }

--- a/calculations.js
+++ b/calculations.js
@@ -1,6 +1,8 @@
-export function calculateLayoutDetails({ sheetWidth, sheetLength, docWidth, docLength, gutterWidth, gutterLength }) {
-    const docsAcross = Math.floor(sheetWidth / (docWidth + gutterWidth));
-    const docsDown = Math.floor(sheetLength / (docLength + gutterLength));
+export function calculateLayoutDetails({ sheetWidth, sheetLength, docWidth, docLength, gutterWidth, gutterLength, marginWidth = 0, marginLength = 0 }) {
+    const usableSheetWidth = sheetWidth - 2 * marginWidth;
+    const usableSheetLength = sheetLength - 2 * marginLength;
+    const docsAcross = Math.floor(usableSheetWidth / (docWidth + gutterWidth));
+    const docsDown = Math.floor(usableSheetLength / (docLength + gutterLength));
     const totalGutterWidth = (docsAcross - 1) * gutterWidth;
     const totalGutterLength = (docsDown - 1) * gutterLength;
     const imposedSpaceWidth = (docWidth * docsAcross) + totalGutterWidth;
@@ -12,10 +14,14 @@ export function calculateLayoutDetails({ sheetWidth, sheetLength, docWidth, docL
     return {
         sheetWidth,
         sheetLength,
+        usableSheetWidth,
+        usableSheetLength,
         docWidth,
         docLength,
         gutterWidth,
         gutterLength,
+        marginWidth,
+        marginLength,
         docsAcross,
         docsDown,
         imposedSpaceWidth,

--- a/tests/calculations.test.js
+++ b/tests/calculations.test.js
@@ -9,25 +9,47 @@ const assert = require('assert');
     docWidth: 3,
     docLength: 4,
     gutterWidth: 0.5,
-    gutterLength: 0.25
+    gutterLength: 0.25,
+    marginWidth: 1,
+    marginLength: 1
   });
 
   // Verify basic layout calculations
-  assert.strictEqual(layout.docsAcross, 3, 'docsAcross incorrect');
-  assert.strictEqual(layout.docsDown, 4, 'docsDown incorrect');
-  assert.strictEqual(layout.topMargin, 0.625, 'topMargin incorrect');
-  assert.strictEqual(layout.leftMargin, 1, 'leftMargin incorrect');
+  assert.strictEqual(layout.usableSheetWidth, 10, 'usableSheetWidth incorrect');
+  assert.strictEqual(layout.usableSheetLength, 16, 'usableSheetLength incorrect');
+  assert.strictEqual(layout.marginWidth, 1, 'marginWidth incorrect');
+  assert.strictEqual(layout.marginLength, 1, 'marginLength incorrect');
+  assert.strictEqual(layout.docsAcross, 2, 'docsAcross incorrect');
+  assert.strictEqual(layout.docsDown, 3, 'docsDown incorrect');
+  assert.strictEqual(layout.topMargin, 2.75, 'topMargin incorrect');
+  assert.strictEqual(layout.leftMargin, 2.75, 'leftMargin incorrect');
 
-  // Verify sequence calculation
-  const expectedSequence = [
-    17.375, 11, 16.75,
-    10, 6.5, 3,
-    3, 3, 12.5,
+  // Verify sequence calculation for actual sheet size
+  const expectedActualSequence = [
+    15.25, 9.25, 12.5,
+    6.5, 3, 3,
     8.25, 4, 4,
-    4, 4
+    4
   ];
-  const sequence = calculateSequence(layout);
-  assert.deepStrictEqual(sequence, expectedSequence, 'Sequence calculation incorrect');
+  const actualSequence = calculateSequence(layout);
+  assert.deepStrictEqual(actualSequence, expectedActualSequence, 'Actual sheet sequence incorrect');
+
+  // Verify sequence calculation for usable sheet size
+  const usableLayout = {
+    ...layout,
+    sheetWidth: layout.usableSheetWidth,
+    sheetLength: layout.usableSheetLength,
+    topMargin: (layout.usableSheetLength - layout.imposedSpaceLength) / 2,
+    leftMargin: (layout.usableSheetWidth - layout.imposedSpaceWidth) / 2
+  };
+  const expectedUsableSequence = [
+    14.25, 8.25, 12.5,
+    6.5, 3, 3,
+    8.25, 4, 4,
+    4
+  ];
+  const usableSequence = calculateSequence(usableLayout);
+  assert.deepStrictEqual(usableSequence, expectedUsableSequence, 'Usable sheet sequence incorrect');
 
 
   console.log('All calculations tests passed');


### PR DESCRIPTION
## Summary
- factor margin width/length into layout calculations and expose usable sheet dimensions
- rotate sheet margins when swapping sheet orientation
- cover margin behavior with updated calculations tests
- compute margins from actual sheet dimensions and validate sequences for usable and full sheets

## Testing
- `node tests/calculations.test.js`
- `node tests/calculateAdaptiveScale.test.js`
- `node tests/scoring.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a7d54493b883248a71d1234c25e7fb