### PR TITLE
Add printable area overlay to layout visualizer

### DIFF
--- a/app.js
+++ b/app.js
@@ -181,7 +181,11 @@ document.addEventListener('DOMContentLoaded', () => {
     // ===== Drawing =====
     // Wrapper function to draw layout using the imported drawLayout function
     function drawLayoutWrapper(layout, scorePositions = []) {
-        drawLayout(elements.canvas, layout, scorePositions);
+        const marginData = {
+            marginWidth: layout.marginWidth,
+            marginLength: layout.marginLength
+        };
+        drawLayout(elements.canvas, layout, scorePositions, marginData);
     }
 
     // ===== Display Functions =====

--- a/style.css
+++ b/style.css
@@ -112,3 +112,9 @@ th {
 .hidden {
     display: none;
 }
+
+/* Printable area overlay */
+.printable-area-overlay {
+    background-color: rgba(255, 0, 255, 0.25);
+    border: 1px dashed magenta;
+}

--- a/visualizer.js
+++ b/visualizer.js
@@ -36,7 +36,7 @@ export function drawDocumentLabels(ctx, layout, scale, offsetX, offsetY) {
 }
 
 // Draw the layout on the canvas
-export function drawLayout(canvas, layout, scorePositions = []) {
+export function drawLayout(canvas, layout, scorePositions = [], marginData = {}) {
     const ctx = canvas.getContext('2d');
     
     // Set canvas size to match its display size
@@ -67,6 +67,57 @@ export function drawLayout(canvas, layout, scorePositions = []) {
         Math.round(layout.sheetWidth * scale),
         Math.round(layout.sheetLength * scale)
     );
+
+    // Draw printable area overlay before documents
+    const marginWidth = marginData.marginWidth ?? 0;
+    const marginLength = marginData.marginLength ?? 0;
+    if (marginWidth > 0 || marginLength > 0) {
+        ctx.fillStyle = 'rgba(255, 0, 255, 0.25)';
+
+        // Top margin
+        ctx.fillRect(
+            Math.round(offsetX),
+            Math.round(offsetY),
+            Math.round(layout.sheetWidth * scale),
+            Math.round(marginLength * scale)
+        );
+
+        // Bottom margin
+        ctx.fillRect(
+            Math.round(offsetX),
+            Math.round(offsetY + (marginLength + layout.usableSheetLength) * scale),
+            Math.round(layout.sheetWidth * scale),
+            Math.round(marginLength * scale)
+        );
+
+        // Left margin
+        ctx.fillRect(
+            Math.round(offsetX),
+            Math.round(offsetY + marginLength * scale),
+            Math.round(marginWidth * scale),
+            Math.round(layout.usableSheetLength * scale)
+        );
+
+        // Right margin
+        ctx.fillRect(
+            Math.round(offsetX + (marginWidth + layout.usableSheetWidth) * scale),
+            Math.round(offsetY + marginLength * scale),
+            Math.round(marginWidth * scale),
+            Math.round(layout.usableSheetLength * scale)
+        );
+
+        // Outline printable area
+        ctx.strokeStyle = 'magenta';
+        ctx.strokeRect(
+            Math.round(offsetX + marginWidth * scale),
+            Math.round(offsetY + marginLength * scale),
+            Math.round(layout.usableSheetWidth * scale),
+            Math.round(layout.usableSheetLength * scale)
+        );
+
+        // Reset stroke for documents
+        ctx.strokeStyle = 'black';
+    }
 
     // Draw documents
     for (let i = 0; i < layout.docsAcross; i++) {


### PR DESCRIPTION
## Summary
- highlight printable area by shading margins and outlining usable sheet size
- add CSS styling for printable-area overlay
- pass margin dimensions into drawLayout to enable overlay

## Testing
- `node tests/calculateAdaptiveScale.test.js`
- `node tests/calculations.test.js`
- `node tests/scoring.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a7da4ea02c83248565e00257e4a76f