### PR TITLE
Add margin-aware layout and scaling tests

### DIFF
--- a/tests/calculateAdaptiveScale.test.js
+++ b/tests/calculateAdaptiveScale.test.js
@@ -3,19 +3,20 @@ const assert = require('assert');
 (async () => {
   const { calculateAdaptiveScale } = await import('../visualizer.js');
 
-  // Case: sheet is wider than canvas
   const canvasWidth = 100;
   const canvasHeight = 200;
-  const layoutWide = { sheetWidth: 300, sheetLength: 100 };
+
+  // Case: sheet is wider than canvas (using usable sheet size)
+  const layoutWide = { sheetWidth: 280, sheetLength: 80 }; // 300x100 with 10 margins on each side
   const expectedWide = (canvasWidth * 0.9) / layoutWide.sheetWidth;
   const scaleWide = calculateAdaptiveScale(layoutWide, canvasWidth, canvasHeight);
-  assert.strictEqual(scaleWide, expectedWide, 'Scale for wider sheet incorrect');
+  assert.strictEqual(scaleWide, expectedWide, 'Scale for margin-adjusted wider sheet incorrect');
 
-  // Case: sheet is taller than canvas
-  const layoutTall = { sheetWidth: 100, sheetLength: 400 };
+  // Case: sheet is taller than canvas (using usable sheet size)
+  const layoutTall = { sheetWidth: 90, sheetLength: 380 }; // 100x400 with 5 width and 10 length margins
   const expectedTall = (canvasHeight * 0.9) / layoutTall.sheetLength;
   const scaleTall = calculateAdaptiveScale(layoutTall, canvasWidth, canvasHeight);
-  assert.strictEqual(scaleTall, expectedTall, 'Scale for taller sheet incorrect');
+  assert.strictEqual(scaleTall, expectedTall, 'Scale for margin-adjusted taller sheet incorrect');
 
   console.log('All calculateAdaptiveScale tests passed');
 })();

--- a/tests/calculations.test.js
+++ b/tests/calculations.test.js
@@ -51,6 +51,21 @@ const assert = require('assert');
   const usableSequence = calculateSequence(usableLayout);
   assert.deepStrictEqual(usableSequence, expectedUsableSequence, 'Usable sheet sequence incorrect');
 
+  // Verify default margins produce matching usable dimensions
+  const noMarginLayout = calculateLayoutDetails({
+    sheetWidth: 10,
+    sheetLength: 20,
+    docWidth: 2,
+    docLength: 3,
+    gutterWidth: 0,
+    gutterLength: 0
+  });
+
+  assert.strictEqual(noMarginLayout.marginWidth, 0, 'Default marginWidth incorrect');
+  assert.strictEqual(noMarginLayout.marginLength, 0, 'Default marginLength incorrect');
+  assert.strictEqual(noMarginLayout.usableSheetWidth, 10, 'usableSheetWidth with zero margins incorrect');
+  assert.strictEqual(noMarginLayout.usableSheetLength, 20, 'usableSheetLength with zero margins incorrect');
+
 
   console.log('All calculations tests passed');
 })();

--- a/tests/drawLayout.test.js
+++ b/tests/drawLayout.test.js
@@ -1,0 +1,57 @@
+const assert = require('assert');
+
+(async () => {
+  const { calculateLayoutDetails } = await import('../calculations.js');
+  const { drawLayout } = await import('../visualizer.js');
+
+  const layout = calculateLayoutDetails({
+    sheetWidth: 12,
+    sheetLength: 18,
+    docWidth: 3,
+    docLength: 4,
+    gutterWidth: 0.5,
+    gutterLength: 0.25,
+    marginWidth: 1,
+    marginLength: 1
+  });
+
+  const ctx = {
+    fillRectCalls: [],
+    strokeRectCalls: [],
+    beginPath() {},
+    moveTo() {},
+    lineTo() {},
+    stroke() {},
+    clearRect() {},
+    translate() {},
+    setLineDash() {},
+    fillText() {},
+    font: '',
+    fillStyle: '',
+    textAlign: '',
+    textBaseline: '',
+    imageSmoothingEnabled: false,
+    strokeRect(x, y, w, h) { this.strokeRectCalls.push({ x, y, w, h }); },
+    fillRect(x, y, w, h) { this.fillRectCalls.push({ x, y, w, h }); }
+  };
+
+  const canvas = {
+    offsetWidth: 200,
+    offsetHeight: 200,
+    width: 0,
+    height: 0,
+    getContext: () => ctx
+  };
+
+  drawLayout(canvas, layout, [], { marginWidth: layout.marginWidth, marginLength: layout.marginLength });
+
+  const scale = (canvas.offsetWidth * 0.8) / layout.sheetWidth;
+  const expectedWidth = Math.round(layout.usableSheetWidth * scale);
+  const expectedHeight = Math.round(layout.usableSheetLength * scale);
+
+  const printableArea = ctx.strokeRectCalls.find(c => c.w === expectedWidth && c.h === expectedHeight);
+  assert.ok(printableArea, 'Printable area not drawn with expected dimensions');
+  assert.strictEqual(ctx.fillRectCalls.length, 4, 'Margins not drawn correctly');
+
+  console.log('All drawLayout tests passed');
+})();


### PR DESCRIPTION
## Summary
- expand calculation tests with default margin assertions
- verify calculateAdaptiveScale handles margin-adjusted sheet sizes
- add drawLayout test to check printable area and margin rendering

## Testing
- `node tests/calculations.test.js && node tests/calculateAdaptiveScale.test.js && node tests/drawLayout.test.js && node tests/scoring.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68a7debc6e38832497d89d63468e788e