### PR TITLE
Add named size options for sheets, docs, and gutters

### DIFF
--- a/app.js
+++ b/app.js
@@ -221,38 +221,32 @@ document.addEventListener('DOMContentLoaded', () => {
         elements.sheetWidth.value = "12.0";
         elements.sheetLength.value = "18.0";
         elements.docWidth.value = "3.5";
-        elements.docLength.value = "2.0";
+        elements.docLength.value = "4.0";
         elements.gutterWidth.value = "0.125";
         elements.gutterLength.value = "0.125";
         elements.marginWidth.value = "0.25";
         elements.marginLength.value = "0.25";
     }
 
-    // Function to select default sizes for sheet, doc, and gutter
+    // Function to select default sizes for sheet, doc, gutter, and margin
     function selectDefaultSizes() {
         const defaultSelections = {
-            sheet: '12 x 18',
-            doc: '3.5 x 2',
-            gutter: '0.125 x 0.125',
-            margin: '0.25 x 0.25'
+            sheet: { width: 12, length: 18 },
+            doc: { width: 3.5, length: 4 },
+            gutter: { width: 0.125, length: 0.125 },
+            margin: { width: 0.25, length: 0.25 }
         };
 
-        Object.entries(defaultSelections).forEach(([type, value]) => {
+        Object.entries(defaultSelections).forEach(([type, { width, length }]) => {
             const container = elements[`${type}Buttons`];
-            const button = Array.from(container.children).find(btn => btn.textContent === value);
+            const button = Array.from(container.children).find(btn =>
+                parseFloat(btn.dataset.width) === width && parseFloat(btn.dataset.length) === length
+            );
             if (button) {
                 button.click();
             } else {
-                // If the default button is not found, set the input values directly
-                if (type === 'gutter') {
-                    const [width, length] = value.split(' x ');
-                    elements.gutterWidth.value = width;
-                    elements.gutterLength.value = length;
-                } else {
-                    const [width, length] = value.split(' x ');
-                    elements[`${type}Width`].value = width;
-                    elements[`${type}Length`].value = length;
-                }
+                elements[`${type}Width`].value = width;
+                elements[`${type}Length`].value = length;
             }
         });
     }

--- a/buttonCreation.js
+++ b/buttonCreation.js
@@ -7,16 +7,14 @@ export function createButtonsForType(type, container, SIZE_OPTIONS) {
         const button = document.createElement('button');
         button.type = 'button';
         button.className = `${type}-size-button`;
-        if (type === 'gutter' || type === 'margin') {
-            button.textContent = `${option.width} x ${option.length}`;
-            button.dataset.width = option.width;
-            button.dataset.length = option.length;
+        if (option.name) {
+            button.innerHTML = `${option.name}<br>${option.width} x ${option.length}`;
+            button.dataset.name = option.name;
         } else {
             button.textContent = `${option.width} x ${option.length}`;
-            button.dataset.width = option.width;
-            button.dataset.length = option.length;
-            if (option.name) button.dataset.name = option.name;
         }
+        button.dataset.width = option.width;
+        button.dataset.length = option.length;
         container.appendChild(button);
     });
 

--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
                     <div class="input-group hidden" id="docDimensionsInputs">
                         <input type="number" id="docWidth" name="docWidth" step="0.25" value="3.5" aria-label="Document Width">
                         <span>x</span>
-                        <input type="number" id="docLength" name="docLength" step="0.25" value="2" aria-label="Document Length">
+                        <input type="number" id="docLength" name="docLength" step="0.25" value="4" aria-label="Document Length">
                     </div>
                 </section>
 

--- a/sizeOptions.js
+++ b/sizeOptions.js
@@ -3,26 +3,24 @@
 // ===== Constants =====
 export const SIZE_OPTIONS = {
     sheet: [
-        { width: 12, length: 18 },
-        { width: 13, length: 19 },
-        { width: 11, length: 17 },
-        { width: 8.5, length: 11 },
-        { width: 26, length: 40 }
+        { width: 12, length: 18, name: "Tabloid Extra" },
+        { width: 13, length: 19, name: "Super B" },
+        { width: 8.5, length: 11, name: "Letter" },
+        { width: 9, length: 12 },
+        { width: 10, length: 13 },
+        { width: 11.5, length: 17.5, name: "Mike's Hemp Paper" },
+        { width: 11, length: 17, name: "Tabloid" },
+        { width: 14.66, length: 25, name: "Awful Oversize" }
     ],
     doc: [
-        { width: 3.5, length: 2, name: "Business Card" },
-        { width: 4, length: 6, name: "Chipotle Opening Card" },
-        { width: 4.25, length: 11, name: "Door Hanger" },
-        { width: 5, length: 7, name: "Invite" },
-        { width: 5.5, length: 8.5, name: "Half Letter" },
-        { width: 6, length: 9, name: "Sunrun Postcard" },
-        { width: 8.5, length: 11, name: "Letter" },
-        { width: 9, length: 12, name: "Rich People Letterhead" },
-        { width: 11, length: 17, name: "Tabloid" }
+        { width: 3.5, length: 4, name: "Folded Business Card" },
+        { width: 4.25, length: 11, name: "Door Hanger" }
     ],
     gutter: [
-        { width: 0.125, length: 0.125 },
-        { width: 0.25, length: 0.25 }
+        { width: 0.125, length: 0.125, name: "1/8" },
+        { width: 0.25, length: 0.25, name: "1/4" },
+        { width: 0, length: 0 },
+        { width: 0.3125, length: 0.17, name: "Duplo 25 UP" }
     ],
     margin: [
         { width: 0.25, length: 0.25 },


### PR DESCRIPTION
## Summary
- Replace sheet size presets with new set and add optional names
- Simplify doc presets to folded business card and door hanger
- Introduce named gutters including Duplo 25 UP and handle unnamed entries
- Display preset names above their dimensions and update default selection logic

## Testing
- `node tests/calculateAdaptiveScale.test.js && node tests/calculations.test.js && node tests/drawLayout.test.js && node tests/scoring.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68a7e1e5672083248399ac555990f040