### PR TITLE
Refactor layout to responsive grid and center tools column

### DIFF
--- a/style.css
+++ b/style.css
@@ -32,17 +32,24 @@ body {
 
 /* Layout */
 .layout {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 10px;
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 1rem;
 }
 
-.main-column {
-    flex: 2 1 60%;
+@media (min-width: 1024px) {
+    .layout {
+        grid-template-columns: 3fr 2fr;
+    }
 }
 
 .tools-column {
-    flex: 1 1 40%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: 100%;
+    max-width: 400px;
+    margin: 0 auto;
 }
 
 /* Typography */


### PR DESCRIPTION
## Summary
- replace flex layout with a single-column grid that expands to two columns on large screens
- center tools column content with a constrained width

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7eb4104408324b106bfa3a0592f14