### PR TITLE
Scale layout canvas to viewport height

### DIFF
--- a/style.css
+++ b/style.css
@@ -41,6 +41,11 @@ body {
     .layout {
         grid-template-columns: 3fr 2fr;
     }
+
+    #layoutCanvas {
+        width: 100%;
+        max-height: 80vh;
+    }
 }
 
 .tools-column {

--- a/tests/drawLayout.test.js
+++ b/tests/drawLayout.test.js
@@ -4,6 +4,8 @@ const assert = require('assert');
   const { calculateLayoutDetails } = await import('../calculations.js');
   const { drawLayout } = await import('../visualizer.js');
 
+  global.window = { innerHeight: 1000 };
+
   const layout = calculateLayoutDetails({
     sheetWidth: 12,
     sheetLength: 18,
@@ -36,8 +38,6 @@ const assert = require('assert');
   };
 
   const canvas = {
-    offsetWidth: 200,
-    offsetHeight: 200,
     width: 0,
     height: 0,
     getContext: () => ctx
@@ -45,7 +45,7 @@ const assert = require('assert');
 
   drawLayout(canvas, layout, [], { marginWidth: layout.marginWidth, marginLength: layout.marginLength });
 
-  const scale = (canvas.offsetWidth * 0.8) / layout.sheetWidth;
+  const scale = (window.innerHeight * 0.8) / layout.sheetLength;
   const expectedWidth = Math.round(layout.usableSheetWidth * scale);
   const expectedHeight = Math.round(layout.usableSheetLength * scale);
 

--- a/visualizer.js
+++ b/visualizer.js
@@ -38,18 +38,17 @@ export function drawDocumentLabels(ctx, layout, scale, offsetX, offsetY) {
 // Draw the layout on the canvas
 export function drawLayout(canvas, layout, scorePositions = [], marginData = {}) {
     const ctx = canvas.getContext('2d');
-    
-    // Set canvas size to match its display size
-    canvas.width = canvas.offsetWidth;
-    canvas.height = canvas.offsetHeight;
-    
-    // Calculate scale to make sheet width 80% of canvas width
-    const scale = (canvas.width * 0.8) / layout.sheetWidth;
 
-    // Scale the canvas height to match the sheet aspect ratio
-    canvas.height = layout.sheetLength * scale * 1.1; // Add 10% for padding
+    // Set canvas height to 80% of the viewport height
+    canvas.height = window.innerHeight * 0.8;
 
-    // Calculate offsets to center the sheet
+    // Scale based on sheet length to fill the canvas height
+    const scale = canvas.height / layout.sheetLength;
+
+    // Set canvas width according to the scale
+    canvas.width = layout.sheetWidth * scale;
+
+    // Calculate offsets to center the sheet within the canvas
     const offsetX = (canvas.width - layout.sheetWidth * scale) / 2;
     const offsetY = (canvas.height - layout.sheetLength * scale) / 2;
 


### PR DESCRIPTION
## Summary
- Scale `drawLayout` canvas height to 80% of viewport and derive width/scale from sheet dimensions.
- Keep layout canvas within tools column on desktop via new media-query rule.
- Update drawLayout test to accommodate new scaling logic.

## Testing
- `node tests/calculateAdaptiveScale.test.js`
- `node tests/calculations.test.js`
- `node tests/drawLayout.test.js`
- `node tests/scoring.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a7ebe8f41483249e32601225a867be