### PR TITLE
Refactor layout into responsive three-column grid

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,54 +11,53 @@
         <h1>Kev's Bitchin' Print Calculator</h1>
                 
         <main class="layout">
-            <div class="main-column">
-            <form>
-                <section class="dimensions-section">
-                    <h2>Sheet Dimensions</h2>
-                    <div class="button-grid" id="sheetButtonsContainer"></div>
-                    <div class="input-group hidden" id="sheetDimensionsInputs">
-                        <input type="number" id="sheetWidth" name="sheetWidth" step="0.25" value="12.0" aria-label="Sheet Width">
-                        <span>x</span>
-                        <input type="number" id="sheetLength" name="sheetLength" step="0.25" value="18.0" aria-label="Sheet Length">
-                    </div>
-                </section>
+            <section class="inputs-column">
+                <form>
+                    <section class="dimensions-section">
+                        <h2>Sheet Dimensions</h2>
+                        <div class="button-grid" id="sheetButtonsContainer"></div>
+                        <div class="input-group hidden" id="sheetDimensionsInputs">
+                            <input type="number" id="sheetWidth" name="sheetWidth" step="0.25" value="12.0" aria-label="Sheet Width">
+                            <span>x</span>
+                            <input type="number" id="sheetLength" name="sheetLength" step="0.25" value="18.0" aria-label="Sheet Length">
+                        </div>
+                    </section>
 
-                <section class="dimensions-section">
-                    <h2>Document Dimensions</h2>
-                    <div class="button-grid" id="docButtonsContainer"></div>
-                    <div class="input-group hidden" id="docDimensionsInputs">
-                        <input type="number" id="docWidth" name="docWidth" step="0.25" value="3.5" aria-label="Document Width">
-                        <span>x</span>
-                        <input type="number" id="docLength" name="docLength" step="0.25" value="4" aria-label="Document Length">
-                    </div>
-                </section>
+                    <section class="dimensions-section">
+                        <h2>Document Dimensions</h2>
+                        <div class="button-grid" id="docButtonsContainer"></div>
+                        <div class="input-group hidden" id="docDimensionsInputs">
+                            <input type="number" id="docWidth" name="docWidth" step="0.25" value="3.5" aria-label="Document Width">
+                            <span>x</span>
+                            <input type="number" id="docLength" name="docLength" step="0.25" value="4" aria-label="Document Length">
+                        </div>
+                    </section>
 
-                <section class="dimensions-section">
-                    <h2>Gutter Sizes</h2>
-                    <div class="button-grid" id="gutterButtonsContainer"></div>
-                    <div class="input-group hidden" id="gutterDimensionsInputs">
-                        <label for="gutterWidth">Gutter Width:</label>
-                        <input type="number" id="gutterWidth" name="gutterWidth" step="0.125" value="0.125">
-                        <label for="gutterLength">Gutter Length:</label>
-                        <input type="number" id="gutterLength" name="gutterLength" step="0.125" value="0.125">
-                    </div>
-                </section>
+                    <section class="dimensions-section">
+                        <h2>Gutter Sizes</h2>
+                        <div class="button-grid" id="gutterButtonsContainer"></div>
+                        <div class="input-group hidden" id="gutterDimensionsInputs">
+                            <label for="gutterWidth">Gutter Width:</label>
+                            <input type="number" id="gutterWidth" name="gutterWidth" step="0.125" value="0.125">
+                            <label for="gutterLength">Gutter Length:</label>
+                            <input type="number" id="gutterLength" name="gutterLength" step="0.125" value="0.125">
+                        </div>
+                    </section>
 
-                <section class="dimensions-section">
-                    <h2>Sheet Margins</h2>
-                    <div class="button-grid" id="marginButtonsContainer"></div>
-                    <div class="input-group hidden" id="marginDimensionsInputs">
-                        <label for="marginWidth">Margin Width:</label>
-                        <input type="number" id="marginWidth" name="marginWidth" step="0.125" value="0.25">
-                        <label for="marginLength">Margin Length:</label>
-                        <input type="number" id="marginLength" name="marginLength" step="0.125" value="0.25">
-                    </div>
-                </section>
-            </form>
-            </div>
+                    <section class="dimensions-section">
+                        <h2>Sheet Margins</h2>
+                        <div class="button-grid" id="marginButtonsContainer"></div>
+                        <div class="input-group hidden" id="marginDimensionsInputs">
+                            <label for="marginWidth">Margin Width:</label>
+                            <input type="number" id="marginWidth" name="marginWidth" step="0.125" value="0.25">
+                            <label for="marginLength">Margin Length:</label>
+                            <input type="number" id="marginLength" name="marginLength" step="0.125" value="0.25">
+                        </div>
+                    </section>
+                </form>
+            </section>
 
-            <aside class="tools-column">
-            <section class="visualizer-section">
+            <section class="visualizer-column">
                 <h2>Layout Visualizer</h2>
                 <div class="button-grid">
                     <button type="button" id="rotateDocsButton">Rotate Docs</button>
@@ -73,7 +72,7 @@
                 </div>
             </section>
 
-            <section>
+            <aside class="data-column">
                 <div id="scoreOptions" class="hidden">
                     <label for="scoredWithMargins">Trim The Margins?</label>
                     <select id="scoredWithMargins">
@@ -90,7 +89,6 @@
                 <div id="layoutDetails" class="hidden" role="status" aria-live="polite"></div>
                 <div id="scorePositions" role="status" aria-live="polite"></div>
                 <div id="programSequence" role="status" aria-live="polite"></div>
-            </section>
             </aside>
         </main>
     </div>

--- a/style.css
+++ b/style.css
@@ -22,10 +22,14 @@ body {
     color: #000;
 }
 
+/* Container styles */
 .container {
-    max-width: 800px;
-    margin: auto;
-    padding: 10px;
+    display: flex;
+    flex-direction: column;
+    max-width: 1440px;
+    margin: 0 auto;
+    padding: 24px;
+    gap: 24px;
     border: 2px solid #000;
     box-shadow: inset 1px 1px #dfdfdf, inset -1px -1px #808080;
 }
@@ -33,28 +37,54 @@ body {
 /* Layout */
 .layout {
     display: grid;
+    gap: 24px;
     grid-template-columns: 1fr;
-    gap: 1rem;
+    grid-template-areas:
+        "visualizer"
+        "inputs"
+        "data";
 }
 
-@media (min-width: 1024px) {
-    .layout {
-        grid-template-columns: 3fr 2fr;
-    }
-
-    #layoutCanvas {
-        width: 100%;
-        max-height: 80vh;
-    }
-}
-
-.tools-column {
+.inputs-column { grid-area: inputs; }
+.visualizer-column {
+    grid-area: visualizer;
+    position: sticky;
+    top: 16px;
     display: flex;
     flex-direction: column;
     align-items: center;
+}
+.data-column { grid-area: data; }
+
+@media (min-width: 1200px) {
+    .layout {
+        grid-template-columns: 420px minmax(560px, 1fr) 360px;
+        grid-template-areas: "inputs visualizer data";
+    }
+}
+
+@media (min-width: 768px) and (max-width: 1199px) {
+    .layout {
+        grid-template-columns: 1fr 420px;
+        grid-template-areas:
+            "visualizer inputs"
+            "data inputs";
+    }
+}
+
+@media (max-width: 767px) {
+    .layout {
+        grid-template-columns: 1fr;
+        grid-template-areas:
+            "visualizer"
+            "inputs"
+            "data";
+    }
+}
+
+#layoutCanvas {
     width: 100%;
-    max-width: 400px;
-    margin: 0 auto;
+    max-height: 80vh;
 }
 
 /* Typography */


### PR DESCRIPTION
## Summary
- Restructure main layout into dedicated Inputs, Visualizer, and Data columns
- Add responsive CSS grid breakpoints with sticky visualizer
- Expand container styles for wider, centered layout

## Testing
- `node tests/calculations.test.js`
- `node tests/drawLayout.test.js`
- `node tests/scoring.test.js`
- `node tests/calculateAdaptiveScale.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a7eea1f4b48324af2f6606f3ed1fcb