### PR TITLE
Normalize spacing and add card layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
         <main class="layout">
             <section class="inputs-column">
                 <form>
-                    <section class="dimensions-section">
+                    <section class="dimensions-section card">
                         <h2>Sheet Dimensions</h2>
                         <div class="button-grid" id="sheetButtonsContainer"></div>
                         <div class="input-group hidden" id="sheetDimensionsInputs">
@@ -23,7 +23,7 @@
                         </div>
                     </section>
 
-                    <section class="dimensions-section">
+                    <section class="dimensions-section card">
                         <h2>Document Dimensions</h2>
                         <div class="button-grid" id="docButtonsContainer"></div>
                         <div class="input-group hidden" id="docDimensionsInputs">
@@ -33,7 +33,7 @@
                         </div>
                     </section>
 
-                    <section class="dimensions-section">
+                    <section class="dimensions-section card">
                         <h2>Gutter Sizes</h2>
                         <div class="button-grid" id="gutterButtonsContainer"></div>
                         <div class="input-group hidden" id="gutterDimensionsInputs">
@@ -44,7 +44,7 @@
                         </div>
                     </section>
 
-                    <section class="dimensions-section">
+                    <section class="dimensions-section card">
                         <h2>Sheet Margins</h2>
                         <div class="button-grid" id="marginButtonsContainer"></div>
                         <div class="input-group hidden" id="marginDimensionsInputs">
@@ -57,7 +57,7 @@
                 </form>
             </section>
 
-            <section class="visualizer-column">
+            <section class="visualizer-column card">
                 <h2>Layout Visualizer</h2>
                 <div class="button-grid">
                     <button type="button" id="rotateDocsButton">Rotate Docs</button>
@@ -72,7 +72,7 @@
                 </div>
             </section>
 
-            <aside class="data-column">
+            <aside class="data-column card">
                 <div id="scoreOptions" class="hidden">
                     <label for="scoredWithMargins">Trim The Margins?</label>
                     <select id="scoredWithMargins">

--- a/style.css
+++ b/style.css
@@ -30,8 +30,14 @@ body {
     margin: 0 auto;
     padding: 24px;
     gap: 24px;
-    border: 2px solid #000;
-    box-shadow: inset 1px 1px #dfdfdf, inset -1px -1px #808080;
+}
+
+/* Card component */
+.card {
+    padding: 24px;
+    border-radius: 8px;
+    border: 1px solid #ccc;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
 /* Layout */
@@ -91,15 +97,15 @@ body {
 h1 {
     font-size: 16px;
     text-align: center;
-    margin: 0 0 10px 0;
-    padding: 5px;
+    margin: 0 0 16px 0;
+    padding: 8px;
     background-color: var(--primary-color);
     color: #fff;
 }
 
 h2 {
     font-size: 14px;
-    margin: 10px 0 5px 0;
+    margin: 16px 0 8px 0;
     color: var(--primary-color);
 }
 
@@ -107,58 +113,53 @@ h2 {
 .button-grid {
     display: grid;
     grid-template-columns: repeat(4, 1fr);
-    gap: 5px;
-    margin-bottom: 10px;
+    gap: 8px;
+    margin-bottom: 16px;
 }
 
 button {
-    padding: 6px 10px;
-    border: 1px solid #000;
-    box-shadow: inset 1px 1px #dfdfdf, inset -1px -1px #808080;
+    padding: 8px 16px;
     cursor: pointer;
     text-align: center;
     width: 100%;
 }
 
 button:active, button.active {
-    box-shadow: inset -1px -1px #dfdfdf, inset 1px 1px var(--primary-color);
     background-color: var(--primary-color);
     color: #fff;
 }
 
 /* Form Styles */
 .dimensions-section {
-    margin-bottom: 10px;
+    margin-bottom: 16px;
 }
 
 input, select {
-    padding: 2px;
-    border: 1px solid #000;
+    padding: 8px;
     background-color: #fff;
 }
 
 /* Margin Section Styles */
 #marginButtonsContainer {
-    margin-bottom: 5px;
+    margin-bottom: 8px;
 }
 
 #marginDimensionsInputs {
     display: flex;
     flex-wrap: wrap;
     align-items: center;
-    gap: 5px;
-    margin-top: 5px;
+    gap: 8px;
+    margin-top: 8px;
 }
 
 #marginDimensionsInputs label {
-    margin-right: 5px;
+    margin-right: 8px;
 }
 
 /* Canvas Styles */
 #layoutCanvas {
-    border: 1px solid #000;
     background-color: #fff;
-    margin-top: 10px;
+    margin-top: 16px;
     width: 100%;
     height: auto;
 }
@@ -167,12 +168,12 @@ input, select {
 table {
     width: 100%;
     border-collapse: collapse;
-    margin-top: 10px;
+    margin-top: 16px;
 }
 
 th, td {
     border: 1px solid #000;
-    padding: 4px;
+    padding: 8px;
     text-align: left;
     font-size: 16px;
 }
@@ -190,10 +191,8 @@ th {
 /* Canvas area overlays */
 .printable-area-overlay {
     background-color: rgba(0, 255, 0, 0.25);
-    border: 1px dashed green;
 }
 
 .margin-area-overlay {
     background-color: rgba(255, 0, 0, 0.25);
-    border: 1px dashed red;
 }


### PR DESCRIPTION
## Summary
- Introduce reusable card component with 24px padding, 8px radius, neutral border, and soft shadow
- Replace inconsistent margins, padding, and gaps with 8/16/24px multiples
- Remove non-card borders while preserving table gridlines

## Testing
- `node tests/calculations.test.js`
- `node tests/drawLayout.test.js`
- `node tests/scoring.test.js`
- `node tests/calculateAdaptiveScale.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a7ef74ccdc8324bd166c1c3dee67e9