### PR TITLE
style: implement accessible type scale

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,13 +1,19 @@
 /*
- * Default Theme Variables
- * --bg-color: #c0c0c0;
- * --primary-color: #000080;
- * --font-family: 'Tahoma', 'Verdana', sans-serif;
+ * Theme variables
+ * --bg: page background
+ * --card: surface color for cards and inputs
+ * --ink: default text color
+ * --border: subtle border color
+ * --blue: accent color
+ * --font-family: base font stack
  */
 
 :root {
-    --bg-color: #c0c0c0;
-    --primary-color: #000080;
+    --bg: #f7f7f9;
+    --card: #fff;
+    --ink: #1f2937;
+    --border: #e5e7eb;
+    --blue: #2563eb;
     --font-family: 'Tahoma', 'Verdana', sans-serif;
 }
 
@@ -16,10 +22,10 @@ body {
     font-family: var(--font-family);
     margin: 0;
     padding: 0;
-    background-color: var(--bg-color);
-    line-height: 1.6;
-    font-size: 12px;
-    color: #000;
+    background-color: var(--bg);
+    line-height: 1.45;
+    font-size: 16px;
+    color: var(--ink);
 }
 
 /* Container styles */
@@ -36,7 +42,8 @@ body {
 .card {
     padding: 24px;
     border-radius: 8px;
-    border: 1px solid #ccc;
+    border: 1px solid var(--border);
+    background-color: var(--card);
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
@@ -95,18 +102,18 @@ body {
 
 /* Typography */
 h1 {
-    font-size: 16px;
+    font-size: 28px;
     text-align: center;
     margin: 0 0 16px 0;
     padding: 8px;
-    background-color: var(--primary-color);
+    background-color: var(--blue);
     color: #fff;
 }
 
 h2 {
-    font-size: 14px;
+    font-size: 20px;
     margin: 16px 0 8px 0;
-    color: var(--primary-color);
+    color: var(--blue);
 }
 
 /* Button Styles */
@@ -125,7 +132,7 @@ button {
 }
 
 button:active, button.active {
-    background-color: var(--primary-color);
+    background-color: var(--blue);
     color: #fff;
 }
 
@@ -136,7 +143,7 @@ button:active, button.active {
 
 input, select {
     padding: 8px;
-    background-color: #fff;
+    background-color: var(--card);
 }
 
 /* Margin Section Styles */
@@ -158,7 +165,7 @@ input, select {
 
 /* Canvas Styles */
 #layoutCanvas {
-    background-color: #fff;
+    background-color: var(--card);
     margin-top: 16px;
     width: 100%;
     height: auto;
@@ -172,15 +179,19 @@ table {
 }
 
 th, td {
-    border: 1px solid #000;
+    border: 1px solid var(--border);
     padding: 8px;
     text-align: left;
-    font-size: 16px;
+    font-size: 14px;
 }
 
 th {
-    background-color: var(--primary-color);
+    background-color: var(--blue);
     color: #fff;
+}
+
+td {
+    font-family: monospace;
 }
 
 /* Utility Classes */


### PR DESCRIPTION
## Summary
- apply new color variables and typography tokens
- scale type for headings, body, and table numerics for accessibility

## Testing
- `node tests/calculateAdaptiveScale.test.js`
- `node tests/calculations.test.js`
- `node tests/drawLayout.test.js`
- `node tests/scoring.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a7f1a9ba0c8324a948da34416fa86a