### PR TITLE
Organize data panels and enhance table presentation

### DIFF
--- a/display.js
+++ b/display.js
@@ -1,26 +1,41 @@
 export function renderProgramSequence(sequence, container) {
-    const html = `
-        <h2>Program Sequence</h2>
+    container.innerHTML = `
+        <div class="card-header">
+            <h2>Program Sequence</h2>
+            <button type="button" class="copy-btn" aria-label="Copy Program Sequence">Copy</button>
+        </div>
         <table>
-            <tr><th>Step</th><th>Cut Measurement</th></tr>
+            <thead>
+                <tr><th>Step</th><th>Cut Measurement</th></tr>
+            </thead>
+            <tbody>
             ${sequence.map((cut, index) => `
                 <tr>
                     <td>${index + 1}</td>
                     <td>${cut.toFixed(3)} inches</td>
                 </tr>
             `).join('')}
+            </tbody>
         </table>
     `;
-    container.innerHTML = html;
+    const copyBtn = container.querySelector('.copy-btn');
+    copyBtn.addEventListener('click', () => {
+        const text = container.querySelector('table').innerText;
+        navigator.clipboard.writeText(text);
+    });
 }
 
 export function renderLayoutDetails(layout, container) {
     const nUp = layout.docsAcross * layout.docsDown;
     const areaUsed = (layout.docWidth * layout.docLength * nUp) /
         (layout.sheetWidth * layout.sheetLength);
-    const html = `
-        <h2>Layout Details</h2>
+    container.innerHTML = `
+        <div class="card-header">
+            <h2>Misc Data</h2>
+            <button type="button" class="copy-btn" aria-label="Copy Misc Data">Copy</button>
+        </div>
         <table>
+            <tbody>
             <tr><th>Sheet Size</th><td>${layout.sheetWidth} x ${layout.sheetLength} in</td></tr>
             <tr><th>Document Size</th><td>${layout.docWidth} x ${layout.docLength} in</td></tr>
             <tr><th>Imposed Space Size</th><td>${layout.imposedSpaceWidth.toFixed(2)} x ${layout.imposedSpaceLength.toFixed(2)} in</td></tr>
@@ -29,18 +44,34 @@ export function renderLayoutDetails(layout, container) {
             <tr><th>Left Margin</th><td>${layout.leftMargin.toFixed(2)} in</td></tr>
             <tr><th>Coverage Percentage / Wasted Percentage</th><td>${(areaUsed * 100).toFixed(2)}% : ${(100 - areaUsed * 100).toFixed(2)}%</td></tr>
             <tr><th>Doc Plus Gutter Size</th><td>${(layout.docWidth + layout.gutterWidth).toFixed(2)} x ${(layout.docLength + layout.gutterLength).toFixed(2)} in</td></tr>
+            </tbody>
         </table>
     `;
-    container.innerHTML = html;
+    const copyBtn = container.querySelector('.copy-btn');
+    copyBtn.addEventListener('click', () => {
+        const text = container.querySelector('table').innerText;
+        navigator.clipboard.writeText(text);
+    });
 }
 
 export function renderScorePositions(scorePositions, container) {
-    const html = `
-        <h2>Score Positions</h2>
+    container.innerHTML = `
+        <div class="card-header">
+            <h2>Score Measurements</h2>
+            <button type="button" class="copy-btn" aria-label="Copy Score Measurements">Copy</button>
+        </div>
         <table>
-            <tr><th>Score Position (inches)</th></tr>
+            <thead>
+                <tr><th>Score Position (inches)</th></tr>
+            </thead>
+            <tbody>
             ${scorePositions.map(pos => `<tr><td>${pos.y.toFixed(3)}</td></tr>`).join('')}
+            </tbody>
         </table>
     `;
-    container.innerHTML = html;
+    const copyBtn = container.querySelector('.copy-btn');
+    copyBtn.addEventListener('click', () => {
+        const text = container.querySelector('table').innerText;
+        navigator.clipboard.writeText(text);
+    });
 }

--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@
                 </div>
             </section>
 
-            <aside class="data-column card">
+            <aside class="data-column">
                 <div id="scoreOptions" class="hidden">
                     <label for="scoredWithMargins">Trim The Margins?</label>
                     <select id="scoredWithMargins">
@@ -95,9 +95,9 @@
                     </select>
                     <button type="button" id="calculateScoresButton" class="btn btn-primary">Calculate Scores</button>
                 </div>
-                <div id="layoutDetails" class="hidden" role="status" aria-live="polite"></div>
-                <div id="scorePositions" role="status" aria-live="polite"></div>
-                <div id="programSequence" role="status" aria-live="polite"></div>
+                <section id="programSequence" class="card data-card" role="status" aria-live="polite"></section>
+                <section id="scorePositions" class="card data-card" role="status" aria-live="polite"></section>
+                <section id="layoutDetails" class="card data-card hidden" role="status" aria-live="polite"></section>
             </aside>
         </main>
     </div>

--- a/style.css
+++ b/style.css
@@ -47,6 +47,30 @@ body {
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
+.data-card {
+    max-height: 480px;
+    overflow: auto;
+}
+
+.card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.copy-btn {
+    padding: 4px 8px;
+    border: 1px solid var(--border);
+    background-color: var(--card);
+    border-radius: 4px;
+    cursor: pointer;
+    font: inherit;
+}
+
+.copy-btn:hover:not([disabled]) {
+    filter: brightness(0.95);
+}
+
 /* Layout */
 .layout {
     display: grid;
@@ -221,20 +245,28 @@ table {
     margin-top: 16px;
 }
 
-th, td {
+th,
+td {
     border: 1px solid var(--border);
     padding: 8px;
-    text-align: left;
     font-size: 14px;
 }
 
 th {
     background-color: var(--blue);
     color: #fff;
+    position: sticky;
+    top: 0;
+    text-align: left;
 }
 
 td {
     font-family: monospace;
+    text-align: right;
+}
+
+tbody tr:nth-child(even) {
+    background-color: var(--bg);
 }
 
 /* Utility Classes */


### PR DESCRIPTION
## Summary
- Split program sequence, score measurements, and misc data into individual scrollable cards
- Added sticky table headers, zebra striping, right-aligned numeric cells, and copy-to-clipboard controls
- Styled new data cards and copy buttons for improved usability

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7fa7446948324a1c6fcadcdde0f01