### PR TITLE
Normalize form control sizing and spacing

### DIFF
--- a/style.css
+++ b/style.css
@@ -59,12 +59,14 @@ body {
 }
 
 .copy-btn {
-    padding: 4px 8px;
+    height: 40px;
+    padding: 0 8px;
     border: 1px solid var(--border);
     background-color: var(--card);
     border-radius: 4px;
     cursor: pointer;
     font: inherit;
+    box-sizing: border-box;
 }
 
 .copy-btn:hover:not([disabled]) {
@@ -228,12 +230,21 @@ h2 {
 }
 
 /* Form Styles */
-.dimensions-section {
-    margin-bottom: 16px;
+form {
+    display: grid;
+    row-gap: 16px;
 }
 
-input, select {
+.dimensions-section {
+    margin: 0;
+}
+
+input,
+select {
+    width: 100%;
+    height: 40px;
     padding: 8px;
+    box-sizing: border-box;
     background-color: var(--card);
 }
 


### PR DESCRIPTION
## Summary
- Standardize button heights and add explicit sizing for copy controls
- Uniformly size inputs for grid layouts and enforce 16px row gaps

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68a7fdd6e4788324971a2064988ebf78