### PR TITLE
Add legend and tooltips for layout visualizer

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,28 +62,52 @@
             <section class="visualizer-column card">
                 <h2>Layout Visualizer</h2>
                 <div class="toolbar" role="toolbar" aria-label="Canvas controls">
-                    <button type="button" id="fitSheetButton" class="btn btn-tertiary" aria-label="Fit sheet">
+                    <button type="button" id="fitSheetButton" class="btn btn-tertiary" aria-label="Fit sheet" aria-describedby="tip-fit">
                         <span class="icon" aria-hidden="true">⤢</span>
+                        <span role="tooltip" id="tip-fit" class="tooltip">Fit sheet</span>
                     </button>
-                    <button type="button" id="zoomOutButton" class="btn btn-tertiary" aria-label="Zoom out">
+                    <button type="button" id="zoomOutButton" class="btn btn-tertiary" aria-label="Zoom out" aria-describedby="tip-zoom-out">
                         <span class="icon" aria-hidden="true">−</span>
+                        <span role="tooltip" id="tip-zoom-out" class="tooltip">Zoom out</span>
                     </button>
-                    <button type="button" id="zoomInButton" class="btn btn-tertiary" aria-label="Zoom in">
+                    <button type="button" id="zoomInButton" class="btn btn-tertiary" aria-label="Zoom in" aria-describedby="tip-zoom-in">
                         <span class="icon" aria-hidden="true">+</span>
+                        <span role="tooltip" id="tip-zoom-in" class="tooltip">Zoom in</span>
                     </button>
-                    <button type="button" id="resetViewButton" class="btn btn-tertiary" aria-label="Reset view">
+                    <button type="button" id="resetViewButton" class="btn btn-tertiary" aria-label="Reset view" aria-describedby="tip-reset">
                         <span class="icon" aria-hidden="true">⟲</span>
+                        <span role="tooltip" id="tip-reset" class="tooltip">Reset view</span>
                     </button>
-                    <button type="button" id="rotateDocsButton" class="btn btn-tertiary" aria-label="Rotate documents">
+                    <button type="button" id="rotateDocsButton" class="btn btn-tertiary" aria-label="Rotate documents" aria-describedby="tip-rotate-docs">
                         <span class="icon" aria-hidden="true">↻</span>
+                        <span role="tooltip" id="tip-rotate-docs" class="tooltip">Rotate documents</span>
                     </button>
-                    <button type="button" id="rotateSheetButton" class="btn btn-tertiary" aria-label="Rotate sheet">
+                    <button type="button" id="rotateSheetButton" class="btn btn-tertiary" aria-label="Rotate sheet" aria-describedby="tip-rotate-sheet">
                         <span class="icon" aria-hidden="true">↻</span>
+                        <span role="tooltip" id="tip-rotate-sheet" class="tooltip">Rotate sheet</span>
                     </button>
                 </div>
                 <div class="canvas-wrapper">
                     <canvas id="layoutCanvas" role="img" aria-label="Layout visualization"></canvas>
                 </div>
+                <ul class="legend" aria-label="Layout legend">
+                    <li class="legend-item">
+                        <span class="legend-swatch doc" aria-hidden="true"></span>
+                        <span>Document</span>
+                    </li>
+                    <li class="legend-item">
+                        <span class="legend-swatch margin" aria-hidden="true"></span>
+                        <span>Margins</span>
+                    </li>
+                    <li class="legend-item">
+                        <span class="legend-swatch printable" aria-hidden="true"></span>
+                        <span>Printable Area</span>
+                    </li>
+                    <li class="legend-item">
+                        <span class="legend-line score" aria-hidden="true"></span>
+                        <span>Score Line</span>
+                    </li>
+                </ul>
                 <div class="button-grid" role="toolbar" aria-label="Data views">
                     <button type="button" id="calculateButton" class="btn btn-primary">Program Sequence</button>
                     <button type="button" id="scoreButton" class="btn btn-secondary">Score Measurements</button>

--- a/style.css
+++ b/style.css
@@ -170,8 +170,31 @@ h2 {
 }
 
 .toolbar .btn {
+    position: relative;
     width: auto;
     padding: 0 8px;
+}
+
+.toolbar .btn .tooltip {
+    position: absolute;
+    bottom: calc(100% + 4px);
+    left: 50%;
+    transform: translateX(-50%);
+    background-color: var(--ink);
+    color: var(--card);
+    padding: 2px 6px;
+    border-radius: 4px;
+    font-size: 12px;
+    white-space: nowrap;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.2s;
+    z-index: 1;
+}
+
+.toolbar .btn:hover .tooltip,
+.toolbar .btn:focus-visible .tooltip {
+    opacity: 1;
 }
 
 .btn {
@@ -306,4 +329,52 @@ tbody tr:nth-child(even) {
 
 .margin-area-overlay {
     background-color: rgba(255, 0, 0, 0.25);
+}
+
+/* Legend styles */
+.legend {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 8px 16px;
+    margin: 8px 0 16px;
+    padding: 0;
+    list-style: none;
+    font-size: 14px;
+}
+
+.legend-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.legend-swatch {
+    width: 16px;
+    height: 16px;
+    border: 2px solid;
+}
+
+.legend-swatch.doc {
+    border-color: black;
+}
+
+.legend-swatch.margin {
+    border-color: red;
+}
+
+.legend-swatch.printable {
+    border-color: magenta;
+    background-color: rgba(255, 0, 255, 0.25);
+}
+
+.legend-line {
+    width: 16px;
+    height: 0;
+    border-top: 2px solid;
+}
+
+.legend-line.score {
+    border-top-style: dashed;
+    border-color: magenta;
 }


### PR DESCRIPTION
## Summary
- Add tooltips with ARIA labels to fit/zoom controls and ensure hover/focus visibility
- Introduce legend mapping document, margin, printable area, and score line colors

## Testing
- `node tests/calculateAdaptiveScale.test.js`
- `node tests/calculations.test.js`
- `node tests/drawLayout.test.js`
- `node tests/scoring.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a806044e88832491bdf748f079e4ed