### PR TITLE
feat: add theme tokens and dark mode toggle

### DIFF
--- a/app.js
+++ b/app.js
@@ -58,7 +58,8 @@ document.addEventListener('DOMContentLoaded', () => {
         scoreOptions: document.getElementById('scoreOptions'),
         scoredWithMargins: document.getElementById('scoredWithMargins'),
         foldType: document.getElementById('foldType'),
-        calculateScoresButton: document.getElementById('calculateScoresButton')
+        calculateScoresButton: document.getElementById('calculateScoresButton'),
+        themeToggle: document.getElementById('themeToggle')
     };
 
     // Zoom state for canvas
@@ -112,6 +113,7 @@ document.addEventListener('DOMContentLoaded', () => {
         elements.scoreButton.addEventListener('click', showScoreOptions);
         elements.miscDataButton.addEventListener('click', toggleMiscData);
         elements.calculateScoresButton.addEventListener('click', calculateScores);
+        elements.themeToggle.addEventListener('click', toggleTheme);
     }
 
     // ===== Event Handlers =====
@@ -269,6 +271,16 @@ document.addEventListener('DOMContentLoaded', () => {
     // Function to show/hide score options
     function showScoreOptions() {
         elements.scoreOptions.classList.toggle('hidden');
+    }
+
+    // Function to toggle between light and dark themes
+    function toggleTheme() {
+        const root = document.documentElement;
+        if (root.getAttribute('data-theme') === 'dark') {
+            root.removeAttribute('data-theme');
+        } else {
+            root.setAttribute('data-theme', 'dark');
+        }
     }
 
 // ===== Scoring =====

--- a/index.html
+++ b/index.html
@@ -9,7 +9,8 @@
 <body>
     <div class="container">
         <h1>Kev's Bitchin' Print Calculator</h1>
-                
+        <button id="themeToggle" class="btn btn-secondary theme-toggle">Toggle Dark Mode</button>
+
         <main class="layout">
             <section class="inputs-column">
                 <form>

--- a/style.css
+++ b/style.css
@@ -9,12 +9,34 @@
  */
 
 :root {
-    --bg: #f7f7f9;
-    --card: #fff;
-    --ink: #1f2937;
-    --border: #e5e7eb;
+    /* Neutral color tokens */
+    --neutral-0: #ffffff;
+    --neutral-50: #f9fafb;
+    --neutral-100: #f3f4f6;
+    --neutral-200: #e5e7eb;
+    --neutral-700: #374151;
+    --neutral-800: #1f2937;
+    --neutral-900: #111827;
+
+    /* Shadow tokens */
+    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
+    --shadow-md: 0 2px 4px rgba(0, 0, 0, 0.1);
+
+    /* Theme variables */
+    --bg: var(--neutral-50);
+    --card: var(--neutral-0);
+    --ink: var(--neutral-800);
+    --border: var(--neutral-200);
     --blue: #2563eb;
     --font-family: 'Tahoma', 'Verdana', sans-serif;
+}
+
+[data-theme="dark"] {
+    --bg: var(--neutral-900);
+    --card: var(--neutral-800);
+    --ink: var(--neutral-0);
+    --border: var(--neutral-700);
+    --blue: #3b82f6;
 }
 
 /* General Styles */
@@ -44,7 +66,7 @@ body {
     border-radius: 8px;
     border: 1px solid var(--border);
     background-color: var(--card);
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    box-shadow: var(--shadow-md);
 }
 
 .data-card {
@@ -212,6 +234,10 @@ h2 {
     background-color: transparent;
     color: var(--ink);
     font: inherit;
+}
+
+.btn.theme-toggle {
+    width: auto;
 }
 
 .btn .icon {


### PR DESCRIPTION
## Summary
- define neutral color and shadow tokens in CSS root and add dark theme palette
- apply shadow token to card surfaces
- add dark mode toggle button and JS handler

## Testing
- `node tests/calculations.test.js`
- `node tests/calculateAdaptiveScale.test.js`
- `node tests/drawLayout.test.js`
- `node tests/scoring.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a807cf08b88324aaf8ca5bed576a17