### PR TITLE
Streamline data display and simplify size buttons

### DIFF
--- a/app.js
+++ b/app.js
@@ -49,9 +49,6 @@ document.addEventListener('DOMContentLoaded', () => {
         resetViewButton: document.getElementById('resetViewButton'),
         rotateDocsButton: document.getElementById('rotateDocsButton'),
         rotateSheetButton: document.getElementById('rotateSheetButton'),
-        calculateButton: document.getElementById('calculateButton'),
-        scoreButton: document.getElementById('scoreButton'),
-        miscDataButton: document.getElementById('miscDataButton'),
         programSequence: document.getElementById('programSequence'),
         layoutDetails: document.getElementById('layoutDetails'),
         scorePositions: document.getElementById('scorePositions'),
@@ -109,9 +106,10 @@ document.addEventListener('DOMContentLoaded', () => {
         elements.resetViewButton.addEventListener('click', () => { zoomFactor = 1; calculateLayout(); });
         elements.rotateDocsButton.addEventListener('click', () => rotateSize('doc'));
         elements.rotateSheetButton.addEventListener('click', () => rotateSize('sheet'));
-        elements.calculateButton.addEventListener('click', calculateLayout);
-        elements.scoreButton.addEventListener('click', showScoreOptions);
-        elements.miscDataButton.addEventListener('click', toggleMiscData);
+        const inputIds = ['sheetWidth', 'sheetLength', 'docWidth', 'docLength', 'gutterWidth', 'gutterLength', 'marginWidth', 'marginLength'];
+        inputIds.forEach(id => {
+            elements[id].addEventListener('input', calculateLayout);
+        });
         elements.calculateScoresButton.addEventListener('click', calculateScores);
         elements.themeToggle.addEventListener('click', toggleTheme);
     }
@@ -263,16 +261,6 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     // ===== UI Toggles =====
-    // Function to toggle display of miscellaneous data
-    function toggleMiscData() {
-        elements.layoutDetails.classList.toggle('hidden');
-    }
-
-    // Function to show/hide score options
-    function showScoreOptions() {
-        elements.scoreOptions.classList.toggle('hidden');
-    }
-
     // Function to toggle between light and dark themes
     function toggleTheme() {
         const root = document.documentElement;

--- a/buttonCreation.js
+++ b/buttonCreation.js
@@ -8,12 +8,7 @@ export function createButtonsForType(type, container, SIZE_OPTIONS) {
         button.type = 'button';
         button.classList.add('btn', 'btn-secondary', `${type}-size-button`);
         button.dataset.type = type;
-        if (option.name) {
-            button.innerHTML = `${option.name}<br>${option.width} x ${option.length}`;
-            button.dataset.name = option.name;
-        } else {
-            button.textContent = `${option.width} x ${option.length}`;
-        }
+        button.textContent = `${option.width} x ${option.length}`;
         button.dataset.width = option.width;
         button.dataset.length = option.length;
         container.appendChild(button);

--- a/index.html
+++ b/index.html
@@ -109,30 +109,28 @@
                         <span>Score Line</span>
                     </li>
                 </ul>
-                <div class="button-grid" role="toolbar" aria-label="Data views">
-                    <button type="button" id="calculateButton" class="btn btn-primary">Program Sequence</button>
-                    <button type="button" id="scoreButton" class="btn btn-secondary">Score Measurements</button>
-                    <button type="button" id="miscDataButton" class="btn btn-secondary">Misc Data</button>
-                </div>
             </section>
 
             <aside class="data-column">
-                <div id="scoreOptions" class="hidden form-grid">
-                    <label for="scoredWithMargins">Trim The Margins?</label>
-                    <select id="scoredWithMargins">
-                        <option value="no">Trim The Margins Then Score</option>
-                        <option value="yes">Score Without Trimming</option>
-                    </select>
-                    <label for="foldType">Fold Type:</label>
-                    <select id="foldType">
-                        <option value="bifold">Bifold</option>
-                        <option value="trifold">Trifold</option>
-                    </select>
-                    <button type="button" id="calculateScoresButton" class="btn btn-primary">Calculate Scores</button>
-                </div>
+                <section id="scoreOptions" class="card data-card">
+                    <h2>Score Options</h2>
+                    <div class="form-grid">
+                        <label for="scoredWithMargins">Trim The Margins?</label>
+                        <select id="scoredWithMargins">
+                            <option value="no">Trim The Margins Then Score</option>
+                            <option value="yes">Score Without Trimming</option>
+                        </select>
+                        <label for="foldType">Fold Type:</label>
+                        <select id="foldType">
+                            <option value="bifold">Bifold</option>
+                            <option value="trifold">Trifold</option>
+                        </select>
+                        <button type="button" id="calculateScoresButton" class="btn btn-primary">Calculate Scores</button>
+                    </div>
+                </section>
                 <section id="programSequence" class="card data-card" role="status" aria-live="polite"></section>
                 <section id="scorePositions" class="card data-card" role="status" aria-live="polite"></section>
-                <section id="layoutDetails" class="card data-card hidden" role="status" aria-live="polite"></section>
+                <section id="layoutDetails" class="card data-card" role="status" aria-live="polite"></section>
             </aside>
         </main>
     </div>

--- a/style.css
+++ b/style.css
@@ -176,10 +176,14 @@ h2 {
 
 /* Button Styles */
 .button-grid {
-    display: grid;
-    grid-template-columns: repeat(4, 1fr);
+    display: flex;
+    flex-wrap: wrap;
     gap: 8px;
     margin-bottom: 16px;
+}
+
+.button-grid .btn {
+    flex: 0 0 auto;
 }
 
 /* Toolbar for canvas controls */


### PR DESCRIPTION
## Summary
- Remove Program Sequence, Score Measurements and Misc Data toggle buttons; show all data panels by default with a new Score Options card
- Only show dimensions on size preset buttons and switch to flex layout so buttons fit their text
- Automatically recalculate layout when any dimension input changes

## Testing
- `node tests/calculations.test.js`
- `node tests/drawLayout.test.js`
- `node tests/scoring.test.js`
- `node tests/calculateAdaptiveScale.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a8149971148324bf714170dde62c01