### PR TITLE
Revamp scoring module with new UI and options

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,18 +113,22 @@
 
             <aside class="data-column">
                 <section id="scoreOptions" class="card data-card">
-                    <h2>Score Options</h2>
+                    <h2>Scoring</h2>
                     <div class="form-grid">
-                        <label for="scoredWithMargins">Trim The Margins?</label>
-                        <select id="scoredWithMargins">
-                            <option value="no">Trim The Margins Then Score</option>
-                            <option value="yes">Score Without Trimming</option>
-                        </select>
-                        <label for="foldType">Fold Type:</label>
+                        <label for="showScores" class="checkbox-label">
+                            <input type="checkbox" id="showScores"> Display scores on visualizer
+                        </label>
+                        <label for="foldType">Score Type:</label>
                         <select id="foldType">
                             <option value="bifold">Bifold</option>
                             <option value="trifold">Trifold</option>
+                            <option value="gatefold">Gatefold</option>
+                            <option value="custom">Custom</option>
                         </select>
+                        <div id="customScoreInputs" class="hidden">
+                            <label for="customScores">Custom Positions (in, comma-separated)</label>
+                            <input type="text" id="customScores" placeholder="e.g., 2,4.5">
+                        </div>
                         <button type="button" id="calculateScoresButton" class="btn btn-primary">Calculate Scores</button>
                     </div>
                 </section>

--- a/scoring.js
+++ b/scoring.js
@@ -1,23 +1,22 @@
 // scoring.js
 // Functions related to scoring positions and other scoring utilities
 
-export function calculateScorePositions(layout, { foldType = 'bifold', scoredWithMargins = false } = {}) {
-    const marginOffset = scoredWithMargins ? layout.topMargin : 0;
-    let scorePositions = [];
+export function calculateScorePositions(layout, foldType = 'bifold', customPositions = []) {
+    const marginOffset = layout.topMargin;
+    const scorePositions = [];
     for (let i = 0; i < layout.docsDown; i++) {
+        const base = i * (layout.docLength + layout.gutterLength) + marginOffset;
         if (foldType === 'bifold') {
-            scorePositions.push({
-                y: (layout.docLength / 2) + i * (layout.docLength + layout.gutterLength) + marginOffset,
-                scoredWithMargins
-            });
+            scorePositions.push({ y: (layout.docLength / 2) + base });
         } else if (foldType === 'trifold') {
-            scorePositions.push({
-                y: (layout.docLength / 3) + i * (layout.docLength + layout.gutterLength) + marginOffset,
-                scoredWithMargins
-            });
-            scorePositions.push({
-                y: (2 * layout.docLength / 3) - 0.05 + i * (layout.docLength + layout.gutterLength) + marginOffset,
-                scoredWithMargins
+            scorePositions.push({ y: (layout.docLength / 3) + base });
+            scorePositions.push({ y: (2 * layout.docLength / 3) - 0.05 + base });
+        } else if (foldType === 'gatefold') {
+            scorePositions.push({ y: (layout.docLength / 4) + base });
+            scorePositions.push({ y: (3 * layout.docLength / 4) - 0.05 + base });
+        } else if (foldType === 'custom') {
+            customPositions.forEach(pos => {
+                scorePositions.push({ y: pos + base });
             });
         }
     }

--- a/tests/scoring.test.js
+++ b/tests/scoring.test.js
@@ -13,15 +13,25 @@ const assert = require('assert');
     gutterLength: 0.25
   });
 
-  // Verify bifold score positions with margins
-  const bifoldScores = calculateScorePositions(layout, { foldType: 'bifold', scoredWithMargins: true });
+  // Verify bifold score positions
+  const bifoldScores = calculateScorePositions(layout, 'bifold');
   assert.strictEqual(bifoldScores.length, 4, 'Bifold score count incorrect');
   assert.strictEqual(bifoldScores[0].y, 2.625, 'First bifold score incorrect');
 
-  // Verify trifold score positions without margins
-  const trifoldScores = calculateScorePositions(layout, { foldType: 'trifold', scoredWithMargins: false });
+  // Verify trifold score positions
+  const trifoldScores = calculateScorePositions(layout, 'trifold');
   assert.strictEqual(trifoldScores.length, 8, 'Trifold score count incorrect');
-  assert.ok(Math.abs(trifoldScores[0].y - 1.3333333333333333) < 1e-9, 'First trifold score incorrect');
+  assert.ok(Math.abs(trifoldScores[0].y - 1.9583333333333333) < 1e-9, 'First trifold score incorrect');
+
+  // Verify gatefold score positions
+  const gatefoldScores = calculateScorePositions(layout, 'gatefold');
+  assert.strictEqual(gatefoldScores.length, 8, 'Gatefold score count incorrect');
+  assert.ok(Math.abs(gatefoldScores[0].y - 1.625) < 1e-9, 'First gatefold score incorrect');
+
+  // Verify custom score positions
+  const customScores = calculateScorePositions(layout, 'custom', [1, 2]);
+  assert.strictEqual(customScores.length, 8, 'Custom score count incorrect');
+  assert.strictEqual(customScores[0].y, 1.625, 'First custom score incorrect');
 
   console.log('All scoring tests passed');
 })();

--- a/visualizer.js
+++ b/visualizer.js
@@ -150,8 +150,7 @@ export function drawLayout(canvas, layout, scorePositions = [], marginData = {},
         ctx.strokeStyle = 'magenta';
         ctx.setLineDash([5, 5]);
         scorePositions.forEach(pos => {
-            // Adjust y position based on whether margins are included
-            const y = offsetY + (pos.scoredWithMargins ? pos.y : pos.y + layout.topMargin) * scale;
+            const y = offsetY + pos.y * scale;
             ctx.beginPath();
             ctx.moveTo(offsetX, Math.round(y));
             ctx.lineTo(offsetX + layout.sheetWidth * scale, Math.round(y));


### PR DESCRIPTION
## Summary
- Replace trimming dropdown with a new Scoring section featuring a checkbox to display scores on the visualizer.
- Expand scoring types to include gatefold and custom; calculations now assume margins remain and support custom positions.
- Update visualizer and tests for new scoring behavior.

## Testing
- `node tests/calculations.test.js`
- `node tests/drawLayout.test.js`
- `node tests/calculateAdaptiveScale.test.js`
- `node tests/scoring.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a81bf03cd88324bbb5c649552eb4e2