### PR TITLE
Revamp scoring UI with gatefold option and visualizer toggle

### DIFF
--- a/app.js
+++ b/app.js
@@ -52,8 +52,8 @@ document.addEventListener('DOMContentLoaded', () => {
         programSequence: document.getElementById('programSequence'),
         layoutDetails: document.getElementById('layoutDetails'),
         scorePositions: document.getElementById('scorePositions'),
-        scoreOptions: document.getElementById('scoreOptions'),
-        scoredWithMargins: document.getElementById('scoredWithMargins'),
+        scoring: document.getElementById('scoring'),
+        showScores: document.getElementById('showScores'),
         foldType: document.getElementById('foldType'),
         calculateScoresButton: document.getElementById('calculateScoresButton'),
         themeToggle: document.getElementById('themeToggle')
@@ -111,6 +111,10 @@ document.addEventListener('DOMContentLoaded', () => {
             elements[id].addEventListener('input', calculateLayout);
         });
         elements.calculateScoresButton.addEventListener('click', calculateScores);
+        elements.showScores.addEventListener('change', () => {
+            const layout = calculateLayoutDetails();
+            drawLayoutWrapper(layout, elements.showScores.checked ? currentScorePositions : []);
+        });
         elements.themeToggle.addEventListener('click', toggleTheme);
     }
 
@@ -162,9 +166,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // ===== Layout Calculation =====
     // Main function to calculate and display layout
+    let currentScorePositions = [];
+
     function calculateLayout() {
         const layout = calculateLayoutDetails();
-        drawLayoutWrapper(layout);
+        drawLayoutWrapper(layout, elements.showScores.checked ? currentScorePositions : []);
         displayProgramSequence(layout);
         displayLayoutDetails(layout);
     }
@@ -274,15 +280,13 @@ document.addEventListener('DOMContentLoaded', () => {
 // ===== Scoring =====
     // Function to calculate and display scores
     function calculateScores() {
-        const scoredWithMargins = elements.scoredWithMargins.value === 'yes';
         const foldType = elements.foldType.value;
         const layout = calculateLayoutDetails();
 
-        const scorePositions = calculateScorePositions(layout, { foldType, scoredWithMargins });
+        const scorePositions = calculateScorePositions(layout, { foldType });
 
-        // Draw the layout with score positions
-        drawLayoutWrapper(layout, scorePositions);
-        // Display the calculated score positions
+        currentScorePositions = scorePositions;
+        drawLayoutWrapper(layout, elements.showScores.checked ? scorePositions : []);
         displayScorePositions(scorePositions);
     }
 

--- a/index.html
+++ b/index.html
@@ -112,18 +112,17 @@
             </section>
 
             <aside class="data-column">
-                <section id="scoreOptions" class="card data-card">
-                    <h2>Score Options</h2>
+                <section id="scoring" class="card data-card">
+                    <h2>Scoring</h2>
                     <div class="form-grid">
-                        <label for="scoredWithMargins">Trim The Margins?</label>
-                        <select id="scoredWithMargins">
-                            <option value="no">Trim The Margins Then Score</option>
-                            <option value="yes">Score Without Trimming</option>
-                        </select>
-                        <label for="foldType">Fold Type:</label>
+                        <label for="showScores">Display Scores on Visualizer</label>
+                        <input type="checkbox" id="showScores">
+                        <label for="foldType">Score Type:</label>
                         <select id="foldType">
                             <option value="bifold">Bifold</option>
                             <option value="trifold">Trifold</option>
+                            <option value="gatefold">Gatefold</option>
+                            <option value="custom">Custom</option>
                         </select>
                         <button type="button" id="calculateScoresButton" class="btn btn-primary">Calculate Scores</button>
                     </div>

--- a/scoring.js
+++ b/scoring.js
@@ -1,24 +1,35 @@
 // scoring.js
 // Functions related to scoring positions and other scoring utilities
 
-export function calculateScorePositions(layout, { foldType = 'bifold', scoredWithMargins = false } = {}) {
-    const marginOffset = scoredWithMargins ? layout.topMargin : 0;
+export function calculateScorePositions(layout, { foldType = 'bifold' } = {}) {
+    const marginOffset = layout.topMargin;
     let scorePositions = [];
     for (let i = 0; i < layout.docsDown; i++) {
         if (foldType === 'bifold') {
             scorePositions.push({
                 y: (layout.docLength / 2) + i * (layout.docLength + layout.gutterLength) + marginOffset,
-                scoredWithMargins
+                scoredWithMargins: true
             });
         } else if (foldType === 'trifold') {
             scorePositions.push({
                 y: (layout.docLength / 3) + i * (layout.docLength + layout.gutterLength) + marginOffset,
-                scoredWithMargins
+                scoredWithMargins: true
             });
             scorePositions.push({
                 y: (2 * layout.docLength / 3) - 0.05 + i * (layout.docLength + layout.gutterLength) + marginOffset,
-                scoredWithMargins
+                scoredWithMargins: true
             });
+        } else if (foldType === 'gatefold') {
+            scorePositions.push({
+                y: (layout.docLength / 4) + i * (layout.docLength + layout.gutterLength) + marginOffset,
+                scoredWithMargins: true
+            });
+            scorePositions.push({
+                y: (3 * layout.docLength / 4) + i * (layout.docLength + layout.gutterLength) + marginOffset,
+                scoredWithMargins: true
+            });
+        } else if (foldType === 'custom') {
+            // Custom scoring to be implemented by user
         }
     }
     return scorePositions;

--- a/tests/scoring.test.js
+++ b/tests/scoring.test.js
@@ -13,15 +13,20 @@ const assert = require('assert');
     gutterLength: 0.25
   });
 
-  // Verify bifold score positions with margins
-  const bifoldScores = calculateScorePositions(layout, { foldType: 'bifold', scoredWithMargins: true });
+  // Verify bifold score positions
+  const bifoldScores = calculateScorePositions(layout, { foldType: 'bifold' });
   assert.strictEqual(bifoldScores.length, 4, 'Bifold score count incorrect');
   assert.strictEqual(bifoldScores[0].y, 2.625, 'First bifold score incorrect');
 
-  // Verify trifold score positions without margins
-  const trifoldScores = calculateScorePositions(layout, { foldType: 'trifold', scoredWithMargins: false });
+  // Verify trifold score positions
+  const trifoldScores = calculateScorePositions(layout, { foldType: 'trifold' });
   assert.strictEqual(trifoldScores.length, 8, 'Trifold score count incorrect');
-  assert.ok(Math.abs(trifoldScores[0].y - 1.3333333333333333) < 1e-9, 'First trifold score incorrect');
+  assert.ok(Math.abs(trifoldScores[0].y - 1.9583333333333333) < 1e-9, 'First trifold score incorrect');
+
+  // Verify gatefold score positions
+  const gatefoldScores = calculateScorePositions(layout, { foldType: 'gatefold' });
+  assert.strictEqual(gatefoldScores.length, 8, 'Gatefold score count incorrect');
+  assert.strictEqual(gatefoldScores[0].y, 1.625, 'First gatefold score incorrect');
 
   console.log('All scoring tests passed');
 })();


### PR DESCRIPTION
## Summary
- Remove margin trimming option and assume scoring occurs before trimming
- Add checkbox to toggle score display on visualizer and gatefold/custom score types
- Support gatefold calculations and update tests

## Testing
- `node tests/calculateAdaptiveScale.test.js`
- `node tests/calculations.test.js`
- `node tests/drawLayout.test.js`
- `node tests/scoring.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a81bf03cd88324bbb5c649552eb4e2