### PR TITLE
feat: customizable fold allowance

### DIFF
--- a/scoring.js
+++ b/scoring.js
@@ -1,7 +1,24 @@
 // scoring.js
 // Functions related to scoring positions and other scoring utilities
 
-export function calculateScorePositions(layout, foldType = 'bifold', customPositions = []) {
+// Default allowance (in inches) to compensate for paper thickness when folding.
+// Thicker paper stocks may require a larger allowance to prevent overlapping folds.
+export const FOLD_ALLOWANCE = 0.05;
+
+/**
+ * Calculate score line positions for a given layout and fold type.
+ * @param {Object} layout - Layout details produced by calculateLayoutDetails.
+ * @param {string} foldType - The type of fold (bifold, trifold, gatefold, custom).
+ * @param {number[]} customPositions - Custom score offsets for 'custom' fold type.
+ * @param {number} allowance - Offset to accommodate paper thickness. Increase for heavier stock,
+ *                             or decrease for thin paper.
+ */
+export function calculateScorePositions(
+    layout,
+    foldType = 'bifold',
+    customPositions = [],
+    allowance = FOLD_ALLOWANCE
+) {
     const marginOffset = layout.topMargin;
     const scorePositions = [];
     for (let i = 0; i < layout.docsDown; i++) {
@@ -10,10 +27,10 @@ export function calculateScorePositions(layout, foldType = 'bifold', customPosit
             scorePositions.push({ y: (layout.docLength / 2) + base });
         } else if (foldType === 'trifold') {
             scorePositions.push({ y: (layout.docLength / 3) + base });
-            scorePositions.push({ y: (2 * layout.docLength / 3) - 0.05 + base });
+            scorePositions.push({ y: (2 * layout.docLength / 3) - allowance + base });
         } else if (foldType === 'gatefold') {
             scorePositions.push({ y: (layout.docLength / 4) + base });
-            scorePositions.push({ y: (3 * layout.docLength / 4) - 0.05 + base });
+            scorePositions.push({ y: (3 * layout.docLength / 4) - allowance + base });
         } else if (foldType === 'custom') {
             customPositions.forEach(pos => {
                 scorePositions.push({ y: pos + base });

--- a/tests/scoring.test.js
+++ b/tests/scoring.test.js
@@ -28,6 +28,13 @@ const assert = require('assert');
   assert.strictEqual(gatefoldScores.length, 8, 'Gatefold score count incorrect');
   assert.ok(Math.abs(gatefoldScores[0].y - 1.625) < 1e-9, 'First gatefold score incorrect');
 
+  // Verify allowance adjustment
+  const trifoldCustomAllowance = calculateScorePositions(layout, 'trifold', [], 0.1);
+  assert.ok(Math.abs(trifoldCustomAllowance[1].y - 3.191666666666666) < 1e-9, 'Trifold custom allowance incorrect');
+
+  const gatefoldCustomAllowance = calculateScorePositions(layout, 'gatefold', [], 0.1);
+  assert.ok(Math.abs(gatefoldCustomAllowance[1].y - 3.525) < 1e-9, 'Gatefold custom allowance incorrect');
+
   // Verify custom score positions
   const customScores = calculateScorePositions(layout, 'custom', [1, 2]);
   assert.strictEqual(customScores.length, 8, 'Custom score count incorrect');


### PR DESCRIPTION
## Summary
- add configurable fold allowance constant and parameter
- allow tests to validate custom allowances for trifold and gatefold

## Testing
- `node tests/calculateAdaptiveScale.test.js && node tests/calculations.test.js && node tests/drawLayout.test.js && node tests/scoring.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a81f46f6148324b81507f1e64ec8eb