### PR TITLE
Validate fold type and sanitize custom scoring positions

### DIFF
--- a/scoring.js
+++ b/scoring.js
@@ -5,6 +5,9 @@
 // Thicker paper stocks may require a larger allowance to prevent overlapping folds.
 export const FOLD_ALLOWANCE = 0.05;
 
+// Supported fold types for calculating score positions
+const SUPPORTED_FOLD_TYPES = ['bifold', 'trifold', 'gatefold', 'custom'];
+
 /**
  * Calculate score line positions for a given layout and fold type.
  * @param {Object} layout - Layout details produced by calculateLayoutDetails.
@@ -19,6 +22,17 @@ export function calculateScorePositions(
     customPositions = [],
     allowance = FOLD_ALLOWANCE
 ) {
+    if (!SUPPORTED_FOLD_TYPES.includes(foldType)) {
+        throw new Error(`Unsupported fold type: ${foldType}`);
+    }
+
+    // Filter and sort custom positions when using the 'custom' fold type
+    const processedCustomPositions = foldType === 'custom'
+        ? customPositions
+              .filter(pos => typeof pos === 'number' && pos >= 0 && pos <= layout.docLength)
+              .sort((a, b) => a - b)
+        : [];
+
     const marginOffset = layout.topMargin;
     const scorePositions = [];
     for (let i = 0; i < layout.docsDown; i++) {
@@ -32,7 +46,7 @@ export function calculateScorePositions(
             scorePositions.push({ y: (layout.docLength / 4) + base });
             scorePositions.push({ y: (3 * layout.docLength / 4) - allowance + base });
         } else if (foldType === 'custom') {
-            customPositions.forEach(pos => {
+            processedCustomPositions.forEach(pos => {
                 scorePositions.push({ y: pos + base });
             });
         }

--- a/tests/scoring.test.js
+++ b/tests/scoring.test.js
@@ -40,5 +40,17 @@ const assert = require('assert');
   assert.strictEqual(customScores.length, 8, 'Custom score count incorrect');
   assert.strictEqual(customScores[0].y, 1.625, 'First custom score incorrect');
 
+  // Verify filtering of out-of-range custom positions
+  const filteredCustomScores = calculateScorePositions(layout, 'custom', [-1, 2, 4, 5, 'a']);
+  assert.strictEqual(filteredCustomScores.length, 8, 'Filtered custom score count incorrect');
+  assert.strictEqual(filteredCustomScores[0].y, layout.topMargin + 2, 'Filtered custom first score incorrect');
+  assert.strictEqual(filteredCustomScores[1].y, layout.topMargin + 4, 'Filtered custom second score incorrect');
+
+  // Verify invalid fold type handling
+  assert.throws(
+    () => calculateScorePositions(layout, 'invalid'),
+    /Unsupported fold type/
+  );
+
   console.log('All scoring tests passed');
 })();


### PR DESCRIPTION
## Summary
- Validate requested fold type against supported options and throw an error when invalid
- Sanitize and sort custom scoring positions
- Test invalid fold types and out-of-range custom positions

## Testing
- `node tests/calculateAdaptiveScale.test.js`
- `node tests/calculations.test.js`
- `node tests/drawLayout.test.js`
- `node tests/scoring.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a81fefce1483248a668f92952ce568