### PR TITLE
style: align checkbox label in form grid

### DIFF
--- a/style.css
+++ b/style.css
@@ -309,6 +309,18 @@ select {
     align-items: center;
 }
 
+.checkbox-label {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    grid-column: 1 / -1;
+}
+
+.checkbox-label input[type="checkbox"] {
+    width: auto;
+    height: auto;
+}
+
 /* Canvas Styles */
 /* Canvas element fills the wrapper */
 #layoutCanvas {


### PR DESCRIPTION
## Summary
- add `.checkbox-label` rule to align checkbox and text in form grid

## Testing
- `for f in tests/*.test.js; do node "$f"; done`

------
https://chatgpt.com/codex/tasks/task_e_68a82175f32483248d20f312a2245225