### PR TITLE
Respect gutters when drawing score lines

### DIFF
--- a/tests/scoreLines.test.js
+++ b/tests/scoreLines.test.js
@@ -1,0 +1,78 @@
+const assert = require('assert');
+
+(async () => {
+  const { calculateLayoutDetails } = await import('../calculations.js');
+  const { calculateScorePositions } = await import('../scoring.js');
+  const { drawLayout } = await import('../visualizer.js');
+
+  const layout = calculateLayoutDetails({
+    sheetWidth: 12,
+    sheetLength: 18,
+    docWidth: 3,
+    docLength: 4,
+    gutterWidth: 0.5,
+    gutterLength: 0.25
+  });
+
+  const scorePositions = calculateScorePositions(layout, 'bifold');
+
+  const ctx = {
+    moveToCalls: [],
+    lineToCalls: [],
+    beginPath() {},
+    moveTo(x, y) { this.moveToCalls.push({ x, y }); },
+    lineTo(x, y) { this.lineToCalls.push({ x, y }); },
+    stroke() {},
+    clearRect() {},
+    translate() {},
+    setLineDash() {},
+    strokeRect() {},
+    fillRect() {},
+    fillText() {},
+    font: '',
+    fillStyle: '',
+    textAlign: '',
+    textBaseline: '',
+    strokeStyle: '',
+    imageSmoothingEnabled: false
+  };
+
+  const container = {
+    clientWidth: 400,
+    clientHeight: 600,
+    style: { setProperty() {} }
+  };
+
+  const canvas = {
+    width: 0,
+    height: 0,
+    parentElement: container,
+    getContext: () => ctx
+  };
+
+  drawLayout(canvas, layout, scorePositions);
+
+  const scale = Math.min(container.clientWidth / layout.sheetWidth, container.clientHeight / layout.sheetLength) * 0.9;
+  const offsetX = (canvas.width - layout.sheetWidth * scale) / 2;
+  const offsetY = (canvas.height - layout.sheetLength * scale) / 2;
+
+  // Ensure a segment was drawn for each column per score line
+  assert.strictEqual(ctx.moveToCalls.length, scorePositions.length * layout.docsAcross);
+  assert.strictEqual(ctx.lineToCalls.length, ctx.moveToCalls.length);
+
+  // Check first segment coordinates
+  const firstY = Math.round(offsetY + scorePositions[0].y * scale);
+  const firstStart = Math.round(offsetX + layout.leftMargin * scale);
+  const firstEnd = Math.round(firstStart + layout.docWidth * scale);
+
+  assert.strictEqual(ctx.moveToCalls[0].x, firstStart, 'First segment start incorrect');
+  assert.strictEqual(ctx.lineToCalls[0].x, firstEnd, 'First segment end incorrect');
+  assert.strictEqual(ctx.moveToCalls[0].y, firstY, 'First segment Y incorrect');
+  assert.strictEqual(ctx.lineToCalls[0].y, firstY, 'First segment Y mismatch');
+
+  // Verify gutter spacing between first two segments
+  const gap = ctx.moveToCalls[1].x - ctx.lineToCalls[0].x;
+  assert.ok(Math.abs(gap - layout.gutterWidth * scale) < 1e-9, 'Gutter width not respected');
+
+  console.log('Score line rendering test passed');
+})();

--- a/visualizer.js
+++ b/visualizer.js
@@ -144,17 +144,20 @@ export function drawLayout(canvas, layout, scorePositions = [], marginData = {},
         Math.round(layout.imposedSpaceLength * scale)
     );
 
-    // Draw score lines
-    // TODO: Add support for different gutter width or length values in calculating the score positions
+    // Draw score lines respecting margins and gutters
     if (scorePositions.length > 0) {
         ctx.strokeStyle = 'magenta';
         ctx.setLineDash([5, 5]);
         scorePositions.forEach(pos => {
             const y = offsetY + pos.y * scale;
-            ctx.beginPath();
-            ctx.moveTo(offsetX, Math.round(y));
-            ctx.lineTo(offsetX + layout.sheetWidth * scale, Math.round(y));
-            ctx.stroke();
+            for (let i = 0; i < layout.docsAcross; i++) {
+                const startX = offsetX + (layout.leftMargin + i * (layout.docWidth + layout.gutterWidth)) * scale;
+                const endX = startX + layout.docWidth * scale;
+                ctx.beginPath();
+                ctx.moveTo(Math.round(startX), Math.round(y));
+                ctx.lineTo(Math.round(endX), Math.round(y));
+                ctx.stroke();
+            }
         });
         ctx.setLineDash([]);
     }


### PR DESCRIPTION
## Summary
- Draw score lines per document span using layout margins and gutter sizes
- Verify score line segments leave gutters clear

## Testing
- `node tests/calculateAdaptiveScale.test.js`
- `node tests/calculations.test.js`
- `node tests/drawLayout.test.js`
- `node tests/scoring.test.js`
- `node tests/scoreLines.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a82b56dfc083249af1f32ae43c71a0