### PR TITLE
Make header sticky and allow visualizer to scroll

### DIFF
--- a/style.css
+++ b/style.css
@@ -56,7 +56,7 @@ body {
     flex-direction: column;
     max-width: 1440px;
     margin: 0 auto;
-    padding: 24px;
+    padding: 0 24px 24px;
     gap: 24px;
 }
 
@@ -109,8 +109,6 @@ body {
 .inputs-column { grid-area: inputs; }
 .visualizer-column {
     grid-area: visualizer;
-    position: sticky;
-    top: 16px;
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -166,6 +164,9 @@ h1 {
     padding: 8px;
     background-color: var(--card);
     color: var(--ink);
+    position: sticky;
+    top: 0;
+    z-index: 10;
 }
 
 h2 {


### PR DESCRIPTION
## Summary
- Remove sticky positioning from visualizer so it scrolls normally on all devices
- Make page title sticky and adjust container padding for a fixed header

## Testing
- `node tests/calculateAdaptiveScale.test.js`
- `node tests/calculations.test.js`
- `node tests/drawLayout.test.js`
- `node tests/scoreLines.test.js`
- `node tests/scoring.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a82c67a05083248825fbacf0674952