### PR TITLE
feat: integrate layout info into visualizer

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,7 +4,7 @@
 import { drawLayout } from './visualizer.js';
 import { calculateLayoutDetails as calcDetails, calculateSequence as calcSequence } from './calculations.js';
 import { calculateScorePositions } from './scoring.js';
-import { renderProgramSequence, renderLayoutDetails, renderScorePositions } from './display.js';
+import { renderProgramSequence, renderScorePositions } from './display.js';
 
 // Import the SIZE_OPTIONS object from the sizeOptions module
 import { SIZE_OPTIONS } from './sizeOptions.js';
@@ -50,8 +50,9 @@ document.addEventListener('DOMContentLoaded', () => {
         rotateDocsButton: document.getElementById('rotateDocsButton'),
         rotateSheetButton: document.getElementById('rotateSheetButton'),
         programSequence: document.getElementById('programSequence'),
-        layoutDetails: document.getElementById('layoutDetails'),
         scorePositions: document.getElementById('scorePositions'),
+        layoutTitle: document.getElementById('layoutTitle'),
+        wasteLegend: document.getElementById('wasteLegend'),
         showScores: document.getElementById('showScores'),
         foldType: document.getElementById('foldType'),
         customScoreInputs: document.getElementById('customScoreInputs'),
@@ -173,7 +174,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const layout = calculateLayoutDetails();
         drawLayoutWrapper(layout, elements.showScores.checked ? lastScorePositions : []);
         displayProgramSequence(layout);
-        displayLayoutDetails(layout);
+        updateLayoutInfo(layout);
         if (lastScorePositions.length > 0) {
             lastScorePositions = [];
             displayScorePositions([]);
@@ -220,9 +221,17 @@ document.addEventListener('DOMContentLoaded', () => {
         renderProgramSequence(sequence, elements.programSequence);
     }
 
-    // Function to display layout details
-    function displayLayoutDetails(layout) {
-        renderLayoutDetails(layout, elements.layoutDetails);
+    // Update title and waste information on the visualizer
+    function updateLayoutInfo(layout) {
+        const nUp = layout.docsAcross * layout.docsDown;
+        const docWidth = parseFloat(layout.docWidth.toFixed(2));
+        const docLength = parseFloat(layout.docLength.toFixed(2));
+        const sheetWidth = parseFloat(layout.sheetWidth.toFixed(2));
+        const sheetLength = parseFloat(layout.sheetLength.toFixed(2));
+        elements.layoutTitle.innerHTML = `<li class="legend-item">${docWidth} x ${docLength} ${nUp}-up on ${sheetWidth} x ${sheetLength}</li>`;
+        const areaUsed = (layout.docWidth * layout.docLength * nUp) / (layout.sheetWidth * layout.sheetLength);
+        const waste = (100 - areaUsed * 100).toFixed(2);
+        elements.wasteLegend.textContent = `Waste: ${waste}%`;
     }
 
     // Function to display score positions

--- a/display.js
+++ b/display.js
@@ -25,35 +25,6 @@ export function renderProgramSequence(sequence, container) {
     });
 }
 
-export function renderLayoutDetails(layout, container) {
-    const nUp = layout.docsAcross * layout.docsDown;
-    const areaUsed = (layout.docWidth * layout.docLength * nUp) /
-        (layout.sheetWidth * layout.sheetLength);
-    container.innerHTML = `
-        <div class="card-header">
-            <h2>Misc Data</h2>
-            <button type="button" class="copy-btn" aria-label="Copy Misc Data">Copy</button>
-        </div>
-        <table>
-            <tbody>
-            <tr><th>Sheet Size</th><td>${layout.sheetWidth} x ${layout.sheetLength} in</td></tr>
-            <tr><th>Document Size</th><td>${layout.docWidth} x ${layout.docLength} in</td></tr>
-            <tr><th>Imposed Space Size</th><td>${layout.imposedSpaceWidth.toFixed(2)} x ${layout.imposedSpaceLength.toFixed(2)} in</td></tr>
-            <tr><th>N-Up</th><td>${nUp} (${layout.docsAcross}x${layout.docsDown})</td></tr>
-            <tr><th>Top Margin</th><td>${layout.topMargin.toFixed(2)} in</td></tr>
-            <tr><th>Left Margin</th><td>${layout.leftMargin.toFixed(2)} in</td></tr>
-            <tr><th>Coverage Percentage / Wasted Percentage</th><td>${(areaUsed * 100).toFixed(2)}% : ${(100 - areaUsed * 100).toFixed(2)}%</td></tr>
-            <tr><th>Doc Plus Gutter Size</th><td>${(layout.docWidth + layout.gutterWidth).toFixed(2)} x ${(layout.docLength + layout.gutterLength).toFixed(2)} in</td></tr>
-            </tbody>
-        </table>
-    `;
-    const copyBtn = container.querySelector('.copy-btn');
-    copyBtn.addEventListener('click', () => {
-        const text = container.querySelector('table').innerText;
-        navigator.clipboard.writeText(text);
-    });
-}
-
 export function renderScorePositions(scorePositions, container) {
     container.innerHTML = `
         <div class="card-header">

--- a/index.html
+++ b/index.html
@@ -62,6 +62,7 @@
 
             <section class="visualizer-column card">
                 <h2>Layout Visualizer</h2>
+                <ul class="legend" id="layoutTitle" aria-label="Layout title"></ul>
                 <div class="toolbar" role="toolbar" aria-label="Canvas controls">
                     <button type="button" id="fitSheetButton" class="btn btn-tertiary" aria-label="Fit sheet" aria-describedby="tip-fit">
                         <span class="icon" aria-hidden="true">⤢</span>
@@ -108,6 +109,7 @@
                         <span class="legend-line score" aria-hidden="true"></span>
                         <span>Score Line</span>
                     </li>
+                    <li class="legend-item" id="wasteLegend"></li>
                 </ul>
             </section>
 
@@ -134,7 +136,6 @@
                 </section>
                 <section id="programSequence" class="card data-card" role="status" aria-live="polite"></section>
                 <section id="scorePositions" class="card data-card" role="status" aria-live="polite"></section>
-                <section id="layoutDetails" class="card data-card" role="status" aria-live="polite"></section>
             </aside>
         </main>
     </div>


### PR DESCRIPTION
## Summary
- remove misc data card from sidebar
- show document size, n-up, and sheet size as a title above the visualizer
- display waste percentage alongside legend items

## Testing
- `for f in tests/*.test.js; do node $f; done`


------
https://chatgpt.com/codex/tasks/task_e_68a82f693c088324a3f0765b73ba4bf5