### PR TITLE
Embed score measurements within scoring card

### DIFF
--- a/display.js
+++ b/display.js
@@ -26,9 +26,10 @@ export function renderProgramSequence(sequence, container) {
 }
 
 export function renderScorePositions(scorePositions, container) {
+    // Render score measurements into the nested #scorePositions div
     container.innerHTML = `
-        <div class="card-header">
-            <h2>Score Measurements</h2>
+        <div class="score-header">
+            <h3>Score Measurements</h3>
             <button type="button" class="copy-btn" aria-label="Copy Score Measurements">Copy</button>
         </div>
         <table>

--- a/index.html
+++ b/index.html
@@ -114,8 +114,13 @@
             </section>
 
             <aside class="data-column">
+                <!-- Program Sequence output card -->
+                <section id="programSequence" class="card data-card" role="status" aria-live="polite"></section>
+
+                <!-- Score options card now contains score positions -->
                 <section id="scoreOptions" class="card data-card">
                     <h2>Scoring</h2>
+                    <!-- Score options controls -->
                     <div class="form-grid">
                         <label for="showScores" class="checkbox-label">
                             <input type="checkbox" id="showScores"> Display scores on visualizer
@@ -133,9 +138,9 @@
                         </div>
                         <button type="button" id="calculateScoresButton" class="btn btn-primary">Calculate Scores</button>
                     </div>
+                    <!-- Nested container for score position output -->
+                    <div id="scorePositions" role="status" aria-live="polite"></div>
                 </section>
-                <section id="programSequence" class="card data-card" role="status" aria-live="polite"></section>
-                <section id="scorePositions" class="card data-card" role="status" aria-live="polite"></section>
             </aside>
         </main>
     </div>

--- a/style.css
+++ b/style.css
@@ -80,6 +80,18 @@ body {
     align-items: center;
 }
 
+/* Sub-header within #scoreOptions for score measurements */
+#scoreOptions .score-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-top: 24px;
+}
+
+#scoreOptions h3 {
+    margin: 0;
+}
+
 .copy-btn {
     height: 40px;
     padding: 0 8px;


### PR DESCRIPTION
## Summary
- move scoring options below program sequence and nest score position output inside
- render score positions with a simple header and table fragment
- style nested score measurements header

## Testing
- `node tests/calculateAdaptiveScale.test.js && node tests/calculations.test.js && node tests/drawLayout.test.js && node tests/scoreLines.test.js && node tests/scoring.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68a8915ec12c8324851d3a2cb85e5f48