### PR TITLE
Remove scrolling from program sequence card

### DIFF
--- a/style.css
+++ b/style.css
@@ -74,6 +74,11 @@ body {
     overflow: auto;
 }
 
+#programSequence {
+    max-height: none;
+    overflow: visible;
+}
+
 .card-header {
     display: flex;
     justify-content: space-between;


### PR DESCRIPTION
## Summary
- Let the program sequence card expand to fit its contents by clearing its max height and overflow

## Testing
- `for f in tests/*.test.js; do echo Running $f; node "$f"; done`


------
https://chatgpt.com/codex/tasks/task_e_68a895c8b6508324b85182d566784780