### PR TITLE
Use grid spacing for data column layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -130,7 +130,11 @@ body {
     flex-direction: column;
     align-items: center;
 }
-.data-column { grid-area: data; }
+.data-column {
+    grid-area: data;
+    display: grid;
+    gap: 16px;
+}
 
 @media (min-width: 1200px) {
     .layout {


### PR DESCRIPTION
## Summary
- Layout `.data-column` as a grid with a 16px gap
- Ensures Program Sequence and Scoring cards align with card spacing across the app

## Testing
- `node tests/calculateAdaptiveScale.test.js`
- `node tests/calculations.test.js`
- `node tests/drawLayout.test.js`
- `node tests/scoreLines.test.js`
- `node tests/scoring.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a896ab70e883248b83c5a62cbe3f5f