### PR TITLE
Refactor size button layout using CSS grid

### DIFF
--- a/buttonCreation.js
+++ b/buttonCreation.js
@@ -19,6 +19,7 @@ export function createButtonsForType(type, container, SIZE_OPTIONS) {
     customButton.type = 'button';
     customButton.id = `custom${type.charAt(0).toUpperCase() + type.slice(1)}SizeButton`;
     customButton.classList.add('btn', 'btn-secondary', `${type}-size-button`);
+    customButton.classList.add('custom-size-button');
     customButton.dataset.type = type;
     customButton.textContent = 'Custom';
     container.appendChild(customButton);

--- a/style.css
+++ b/style.css
@@ -198,15 +198,15 @@ h2 {
 
 /* Button Styles */
 .button-grid {
-    display: flex;
-    flex-wrap: wrap;
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
     gap: 8px;
     margin-bottom: 16px;
 }
 
-.button-grid .btn {
-    flex: 0 0 auto;
-}
+.button-grid .btn { width: 100%; }
+
+.button-grid .custom-size-button { grid-column: 1 / -1; }
 
 /* Toolbar for canvas controls */
 .toolbar {


### PR DESCRIPTION
## Summary
- Add dedicated `custom-size-button` class for custom size buttons
- Replace flex-based size button grid with a two-column CSS grid and full-width custom button
- Confirm custom input groups remain outside the button grid for separate layout

## Testing
- `node tests/calculations.test.js`
- `node tests/calculateAdaptiveScale.test.js`
- `node tests/drawLayout.test.js`
- `node tests/scoreLines.test.js`
- `node tests/scoring.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a897dc4e2883248baa0a008b04fae8