### PR TITLE
Improve document label sizing

### DIFF
--- a/tests/drawLayout.test.js
+++ b/tests/drawLayout.test.js
@@ -26,6 +26,7 @@ const assert = require('assert');
     translate() {},
     setLineDash() {},
     fillText() {},
+    measureText(text) { return { width: text.length * 100 }; },
     font: '',
     fillStyle: '',
     textAlign: '',

--- a/tests/scoreLines.test.js
+++ b/tests/scoreLines.test.js
@@ -29,6 +29,7 @@ const assert = require('assert');
     strokeRect() {},
     fillRect() {},
     fillText() {},
+    measureText(text) { return { width: text.length * 100 }; },
     font: '',
     fillStyle: '',
     textAlign: '',

--- a/visualizer.js
+++ b/visualizer.js
@@ -19,7 +19,6 @@ export function calculateAdaptiveScale(layout, canvasWidth, canvasHeight) {
 
 // Draw document labels on the canvas
 export function drawDocumentLabels(ctx, layout, scale, offsetX, offsetY) {
-    ctx.font = '12px Arial';
     ctx.fillStyle = 'blue';
     ctx.textAlign = 'center';
     ctx.textBaseline = 'middle';
@@ -29,7 +28,20 @@ export function drawDocumentLabels(ctx, layout, scale, offsetX, offsetY) {
         for (let j = 0; j < layout.docsDown; j++) {
             const x = offsetX + (layout.leftMargin + (i + 0.5) * (layout.docWidth + layout.gutterWidth)) * scale;
             const y = offsetY + (layout.topMargin + (j + 0.5) * (layout.docLength + layout.gutterLength)) * scale;
-            ctx.fillText(docNumber.toString(), x, y);
+
+            const desiredWidth = layout.docWidth * scale * 0.8;
+            const numberStr = docNumber.toString();
+            ctx.font = '100px Arial';
+            const measuredWidth = ctx.measureText(numberStr).width;
+            const numberFontSize = (desiredWidth / measuredWidth) * 100;
+            const subFontSize = numberFontSize * 0.8;
+
+            ctx.font = `${numberFontSize}px Arial`;
+            ctx.fillText(numberStr, x, y - subFontSize / 2);
+
+            ctx.font = `${subFontSize}px Arial`;
+            ctx.fillText(`${layout.docWidth}x${layout.docLength}`, x, y + numberFontSize / 2);
+
             docNumber++;
         }
     }


### PR DESCRIPTION
## Summary
- Dynamically size document numbers and dimensions in `drawDocumentLabels` to fit within each sheet cell.
- Extend test canvas mocks with `measureText` to support new label rendering logic.

## Testing
- `node tests/calculateAdaptiveScale.test.js`
- `node tests/calculations.test.js`
- `node tests/drawLayout.test.js`
- `node tests/scoreLines.test.js`
- `node tests/scoring.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a89c2c7bcc8324880e7f48c1d1cb0d