### PR TITLE
feat: apply Windows 98 theme

### DIFF
--- a/style.css
+++ b/style.css
@@ -9,34 +9,25 @@
  */
 
 :root {
-    /* Neutral color tokens */
-    --neutral-0: #ffffff;
-    --neutral-50: #f9fafb;
-    --neutral-100: #f3f4f6;
-    --neutral-200: #e5e7eb;
-    --neutral-700: #374151;
-    --neutral-800: #1f2937;
-    --neutral-900: #111827;
-
     /* Shadow tokens */
     --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
     --shadow-md: 0 2px 4px rgba(0, 0, 0, 0.1);
 
     /* Theme variables */
-    --bg: var(--neutral-50);
-    --card: var(--neutral-0);
-    --ink: var(--neutral-800);
-    --border: var(--neutral-200);
-    --blue: #2563eb;
+    --bg: #C0C0C0;
+    --card: #FFFFFF;
+    --ink: #000000;
+    --border: #808080;
+    --blue: #000080;
     --font-family: 'Tahoma', 'Verdana', sans-serif;
 }
 
 [data-theme="dark"] {
-    --bg: var(--neutral-900);
-    --card: var(--neutral-800);
-    --ink: var(--neutral-0);
-    --border: var(--neutral-700);
-    --blue: #3b82f6;
+    --bg: #000000;
+    --card: #C0C0C0;
+    --ink: #FFFFFF;
+    --border: #808080;
+    --blue: #000080;
 }
 
 /* General Styles */


### PR DESCRIPTION
## Summary
- restyle theme variables to Windows 98 palette for light and dark modes
- propagate color tokens through body, cards, and headings

## Testing
- `node tests/calculateAdaptiveScale.test.js && node tests/calculations.test.js && node tests/drawLayout.test.js && node tests/scoreLines.test.js && node tests/scoring.test.js`
- `node - <<'NODE'
const fs = require('fs');
const {JSDOM} = require('jsdom');

(async () => {
  const css = fs.readFileSync('style.css', 'utf8');
  const html = `<!DOCTYPE html><html><head><style>${css}</style></head><body></body></html>`;
  const dom = new JSDOM(html, { pretendToBeVisual: true });
  const root = dom.window.document.documentElement;

  const getBg = () => dom.window.getComputedStyle(root).getPropertyValue('--bg').trim();

  console.log('Initial bg:', getBg());
  root.setAttribute('data-theme', 'dark');
  console.log('Dark bg:', getBg());
  root.removeAttribute('data-theme');
  console.log('Light bg:', getBg());
})();
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68a8e9eb25588324a6e8442ddb94c549