### PR TITLE
Add visualizer display toggles

### DIFF
--- a/app.js
+++ b/app.js
@@ -54,6 +54,9 @@ document.addEventListener('DOMContentLoaded', () => {
         layoutTitle: document.getElementById('layoutTitle'),
         wasteLegend: document.getElementById('wasteLegend'),
         showScores: document.getElementById('showScores'),
+        showDocNumbers: document.getElementById('showDocNumbers'),
+        showPrintableArea: document.getElementById('showPrintableArea'),
+        showMargins: document.getElementById('showMargins'),
         foldType: document.getElementById('foldType'),
         customScoreInputs: document.getElementById('customScoreInputs'),
         customScores: document.getElementById('customScores'),
@@ -115,9 +118,11 @@ document.addEventListener('DOMContentLoaded', () => {
         });
         elements.calculateScoresButton.addEventListener('click', calculateScores);
         elements.foldType.addEventListener('change', toggleCustomInputs);
-        elements.showScores.addEventListener('change', () => {
-            const layout = calculateLayoutDetails();
-            drawLayoutWrapper(layout, elements.showScores.checked ? lastScorePositions : []);
+        ['showScores', 'showDocNumbers', 'showPrintableArea', 'showMargins'].forEach(id => {
+            elements[id].addEventListener('change', () => {
+                const layout = calculateLayoutDetails();
+                drawLayoutWrapper(layout, elements.showScores.checked ? lastScorePositions : []);
+            });
         });
         elements.themeToggle.addEventListener('click', toggleTheme);
     }
@@ -211,7 +216,12 @@ document.addEventListener('DOMContentLoaded', () => {
             marginWidth: layout.marginWidth,
             marginLength: layout.marginLength
         };
-        drawLayout(elements.canvas, layout, scorePositions, marginData, zoomFactor);
+        const options = {
+            showDocNumbers: elements.showDocNumbers.checked,
+            showPrintableArea: elements.showPrintableArea.checked,
+            showMargins: elements.showMargins.checked
+        };
+        drawLayout(elements.canvas, layout, scorePositions, marginData, zoomFactor, options);
     }
 
     // ===== Display Functions =====

--- a/index.html
+++ b/index.html
@@ -91,6 +91,20 @@
                         <span role="tooltip" id="tip-rotate-sheet" class="tooltip">Rotate sheet</span>
                     </button>
                 </div>
+                <div class="visualizer-options">
+                    <label for="showScores" class="checkbox-label">
+                        <input type="checkbox" id="showScores"> Display scores
+                    </label>
+                    <label for="showDocNumbers" class="checkbox-label">
+                        <input type="checkbox" id="showDocNumbers" checked> Show document numbers
+                    </label>
+                    <label for="showPrintableArea" class="checkbox-label">
+                        <input type="checkbox" id="showPrintableArea" checked> Show printable area
+                    </label>
+                    <label for="showMargins" class="checkbox-label">
+                        <input type="checkbox" id="showMargins" checked> Show margins
+                    </label>
+                </div>
                 <div class="canvas-wrapper">
                     <canvas id="layoutCanvas" role="img" aria-label="Layout visualization"></canvas>
                 </div>
@@ -124,9 +138,6 @@
                     <h2>Scoring</h2>
                     <!-- Score options controls -->
                     <div class="form-grid">
-                        <label for="showScores" class="checkbox-label">
-                            <input type="checkbox" id="showScores"> Display scores on visualizer
-                        </label>
                         <label for="foldType">Score Type:</label>
                         <select id="foldType">
                             <option value="bifold">Bifold</option>

--- a/style.css
+++ b/style.css
@@ -226,6 +226,14 @@ h2 {
     margin-bottom: 16px;
 }
 
+.visualizer-options {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 8px;
+    margin-bottom: 16px;
+}
+
 .toolbar .btn {
     position: relative;
     width: auto;

--- a/tests/drawLayout.test.js
+++ b/tests/drawLayout.test.js
@@ -1,5 +1,8 @@
 const assert = require('assert');
 
+(globalThis.document = { documentElement: {} });
+(globalThis.getComputedStyle = () => ({ getPropertyValue: () => '' }));
+
 (async () => {
   const { calculateLayoutDetails } = await import('../calculations.js');
   const { drawLayout } = await import('../visualizer.js');

--- a/tests/scoreLines.test.js
+++ b/tests/scoreLines.test.js
@@ -1,5 +1,8 @@
 const assert = require('assert');
 
+(globalThis.document = { documentElement: {} });
+(globalThis.getComputedStyle = () => ({ getPropertyValue: () => '' }));
+
 (async () => {
   const { calculateLayoutDetails } = await import('../calculations.js');
   const { calculateScorePositions } = await import('../scoring.js');

--- a/visualizer.js
+++ b/visualizer.js
@@ -38,9 +38,14 @@ export function drawDocumentLabels(ctx, layout, scale, offsetX, offsetY) {
 }
 
 // Draw the layout on the canvas
-export function drawLayout(canvas, layout, scorePositions = [], marginData = {}, zoom = 1) {
+export function drawLayout(canvas, layout, scorePositions = [], marginData = {}, zoom = 1, options = {}) {
     const ctx = canvas.getContext('2d');
     const colors = getColorTokens();
+    const {
+        showDocNumbers = true,
+        showPrintableArea = true,
+        showMargins = true
+    } = options;
 
     const container = canvas.parentElement;
     if (container && container.style) {
@@ -76,7 +81,7 @@ export function drawLayout(canvas, layout, scorePositions = [], marginData = {},
     // Draw printable area overlay before documents
     const marginWidth = marginData.marginWidth ?? 0;
     const marginLength = marginData.marginLength ?? 0;
-    if (marginWidth > 0 || marginLength > 0) {
+    if (showPrintableArea && (marginWidth > 0 || marginLength > 0)) {
         ctx.fillStyle = colors.printableFill;
 
         // Top margin
@@ -139,13 +144,15 @@ export function drawLayout(canvas, layout, scorePositions = [], marginData = {},
     }
 
     // Draw margins
-    ctx.strokeStyle = colors.margin;
-    ctx.strokeRect(
-        Math.round(offsetX + layout.leftMargin * scale),
-        Math.round(offsetY + layout.topMargin * scale),
-        Math.round(layout.imposedSpaceWidth * scale),
-        Math.round(layout.imposedSpaceLength * scale)
-    );
+    if (showMargins) {
+        ctx.strokeStyle = colors.margin;
+        ctx.strokeRect(
+            Math.round(offsetX + layout.leftMargin * scale),
+            Math.round(offsetY + layout.topMargin * scale),
+            Math.round(layout.imposedSpaceWidth * scale),
+            Math.round(layout.imposedSpaceLength * scale)
+        );
+    }
 
     // Draw score lines respecting margins and gutters
     if (scorePositions.length > 0) {
@@ -167,5 +174,7 @@ export function drawLayout(canvas, layout, scorePositions = [], marginData = {},
 
     ctx.translate(-0.5, -0.5);
     // Draw document labels
-    drawDocumentLabels(ctx, layout, scale, offsetX, offsetY);
+    if (showDocNumbers) {
+        drawDocumentLabels(ctx, layout, scale, offsetX, offsetY);
+    }
 }


### PR DESCRIPTION
## Summary
- Move scoring checkbox below visualizer toolbar and add toggles for document numbers, printable area, and margins
- Wire new controls into drawing logic so layout updates in real time
- Update tests to run in a headless Node environment

## Testing
- `node tests/calculations.test.js`
- `node tests/calculateAdaptiveScale.test.js`
- `node tests/drawLayout.test.js`
- `node tests/scoreLines.test.js`
- `node tests/scoring.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a8efeddd2483249a606d8a5662ff56