### PR TITLE
Refactor layout rendering into modular helpers

### DIFF
--- a/src/render/drawDocumentLabels.js
+++ b/src/render/drawDocumentLabels.js
@@ -1,0 +1,20 @@
+export function drawDocumentLabels(ctx, layout, scale, offsetX, offsetY, options = {}) {
+    const { showDocNumbers = true, colors } = options;
+    if (!showDocNumbers) {
+        return;
+    }
+    ctx.font = '12px Arial';
+    ctx.fillStyle = colors.label;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+
+    let docNumber = 1;
+    for (let i = 0; i < layout.docsAcross; i++) {
+        for (let j = 0; j < layout.docsDown; j++) {
+            const x = offsetX + (layout.leftMargin + (i + 0.5) * (layout.docWidth + layout.gutterWidth)) * scale;
+            const y = offsetY + (layout.topMargin + (j + 0.5) * (layout.docLength + layout.gutterLength)) * scale;
+            ctx.fillText(docNumber.toString(), x, y);
+            docNumber++;
+        }
+    }
+}

--- a/src/render/drawDocuments.js
+++ b/src/render/drawDocuments.js
@@ -1,0 +1,16 @@
+export function drawDocuments(ctx, layout, scale, offsetX, offsetY, options = {}) {
+    const { colors } = options;
+    ctx.strokeStyle = colors.document;
+    for (let i = 0; i < layout.docsAcross; i++) {
+        for (let j = 0; j < layout.docsDown; j++) {
+            const x = offsetX + (layout.leftMargin + i * (layout.docWidth + layout.gutterWidth)) * scale;
+            const y = offsetY + (layout.topMargin + j * (layout.docLength + layout.gutterLength)) * scale;
+            ctx.strokeRect(
+                Math.round(x),
+                Math.round(y),
+                Math.round(layout.docWidth * scale),
+                Math.round(layout.docLength * scale)
+            );
+        }
+    }
+}

--- a/src/render/drawMargins.js
+++ b/src/render/drawMargins.js
@@ -1,0 +1,13 @@
+export function drawMargins(ctx, layout, scale, offsetX, offsetY, options = {}) {
+    const { colors, showMargins = true } = options;
+    if (!showMargins) {
+        return;
+    }
+    ctx.strokeStyle = colors.margin;
+    ctx.strokeRect(
+        Math.round(offsetX + layout.leftMargin * scale),
+        Math.round(offsetY + layout.topMargin * scale),
+        Math.round(layout.imposedSpaceWidth * scale),
+        Math.round(layout.imposedSpaceLength * scale)
+    );
+}

--- a/src/render/drawPrintableArea.js
+++ b/src/render/drawPrintableArea.js
@@ -1,0 +1,54 @@
+export function drawPrintableArea(ctx, layout, scale, offsetX, offsetY, options = {}) {
+    const { colors, showPrintableArea = true, marginData = {} } = options;
+    const marginWidth = marginData.marginWidth ?? 0;
+    const marginLength = marginData.marginLength ?? 0;
+    if (!showPrintableArea || (marginWidth <= 0 && marginLength <= 0)) {
+        return;
+    }
+
+    ctx.fillStyle = colors.printableFill;
+
+    // Top margin
+    ctx.fillRect(
+        Math.round(offsetX),
+        Math.round(offsetY),
+        Math.round(layout.sheetWidth * scale),
+        Math.round(marginLength * scale)
+    );
+
+    // Bottom margin
+    ctx.fillRect(
+        Math.round(offsetX),
+        Math.round(offsetY + (marginLength + layout.usableSheetLength) * scale),
+        Math.round(layout.sheetWidth * scale),
+        Math.round(marginLength * scale)
+    );
+
+    // Left margin
+    ctx.fillRect(
+        Math.round(offsetX),
+        Math.round(offsetY + marginLength * scale),
+        Math.round(marginWidth * scale),
+        Math.round(layout.usableSheetLength * scale)
+    );
+
+    // Right margin
+    ctx.fillRect(
+        Math.round(offsetX + (marginWidth + layout.usableSheetWidth) * scale),
+        Math.round(offsetY + marginLength * scale),
+        Math.round(marginWidth * scale),
+        Math.round(layout.usableSheetLength * scale)
+    );
+
+    // Outline printable area
+    ctx.strokeStyle = colors.score;
+    ctx.strokeRect(
+        Math.round(offsetX + marginWidth * scale),
+        Math.round(offsetY + marginLength * scale),
+        Math.round(layout.usableSheetWidth * scale),
+        Math.round(layout.usableSheetLength * scale)
+    );
+
+    // Reset stroke for documents
+    ctx.strokeStyle = colors.document;
+}

--- a/src/render/drawScoreLines.js
+++ b/src/render/drawScoreLines.js
@@ -1,0 +1,20 @@
+export function drawScoreLines(ctx, layout, scale, offsetX, offsetY, options = {}) {
+    const { colors, scorePositions = [] } = options;
+    if (!scorePositions.length) {
+        return;
+    }
+    ctx.strokeStyle = colors.score;
+    ctx.setLineDash([5, 5]);
+    scorePositions.forEach(pos => {
+        const y = offsetY + pos.y * scale;
+        for (let i = 0; i < layout.docsAcross; i++) {
+            const startX = offsetX + (layout.leftMargin + i * (layout.docWidth + layout.gutterWidth)) * scale;
+            const endX = startX + layout.docWidth * scale;
+            ctx.beginPath();
+            ctx.moveTo(Math.round(startX), Math.round(y));
+            ctx.lineTo(Math.round(endX), Math.round(y));
+            ctx.stroke();
+        }
+    });
+    ctx.setLineDash([]);
+}

--- a/src/render/drawSheet.js
+++ b/src/render/drawSheet.js
@@ -1,0 +1,10 @@
+export function drawSheet(ctx, layout, scale, offsetX, offsetY, options = {}) {
+    const { colors } = options;
+    ctx.strokeStyle = colors.document;
+    ctx.strokeRect(
+        Math.round(offsetX),
+        Math.round(offsetY),
+        Math.round(layout.sheetWidth * scale),
+        Math.round(layout.sheetLength * scale)
+    );
+}

--- a/tests/drawLayout.test.js
+++ b/tests/drawLayout.test.js
@@ -6,6 +6,7 @@ const assert = require('assert');
 (async () => {
   const { calculateLayoutDetails } = await import('../calculations.js');
   const { drawLayout } = await import('../visualizer.js');
+  const { drawPrintableArea } = await import('../src/render/drawPrintableArea.js');
 
   const layout = calculateLayoutDetails({
     sheetWidth: 12,
@@ -60,6 +61,16 @@ const assert = require('assert');
   const printableArea = ctx.strokeRectCalls.find(c => c.w === expectedWidth && c.h === expectedHeight);
   assert.ok(printableArea, 'Printable area not drawn with expected dimensions');
   assert.strictEqual(ctx.fillRectCalls.length, 4, 'Margins not drawn correctly');
+
+  // Test the modular printable area function
+  ctx.fillRectCalls = [];
+  ctx.strokeRectCalls = [];
+  drawPrintableArea(ctx, layout, scale, 0, 0, {
+    marginData: { marginWidth: layout.marginWidth, marginLength: layout.marginLength },
+    colors: {},
+    showPrintableArea: true
+  });
+  assert.strictEqual(ctx.fillRectCalls.length, 4, 'drawPrintableArea did not draw four margins');
 
   console.log('All drawLayout tests passed');
 })();


### PR DESCRIPTION
## Summary
- Modularize rendering logic into `src/render` helpers (sheet, printable area, documents, margins, score lines, labels)
- Simplify `drawLayout` to compute layout and delegate to new helpers
- Extend tests to cover `drawPrintableArea`

## Testing
- `node tests/drawLayout.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a905a626c48324a2987d76bf6aec7b