### PR TITLE
Add metric mode to toggle between inches and millimeters

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,7 +2,7 @@ import { elements } from './src/ui/elements.js';
 import { registerEventListeners } from './src/ui/events.js';
 import { setDefaultValues, selectDefaultSizes, calculateLayout } from './src/layout/layoutController.js';
 import { createSizeButtons } from './src/ui/buttonCreation.js';
-import { SIZE_OPTIONS } from './src/config/sizeOptions.js';
+import { INCH_SIZE_OPTIONS } from './src/config/sizeOptions.js';
 
 function init() {
     createSizeButtons({
@@ -10,7 +10,7 @@ function init() {
         docButtons: elements.docButtons,
         gutterButtons: elements.gutterButtons,
         marginButtons: elements.marginButtons
-    }, SIZE_OPTIONS);
+    }, INCH_SIZE_OPTIONS);
     setDefaultValues(elements);
     selectDefaultSizes(elements);
     registerEventListeners(elements);

--- a/index.html
+++ b/index.html
@@ -12,6 +12,9 @@
     <div class="container">
         <h1>Kev's Bitchin' Print Calculator</h1>
         <button id="themeToggle" class="btn btn-secondary theme-toggle">Toggle Dark Mode</button>
+        <label for="metricToggle" class="checkbox-label">
+            <input type="checkbox" id="metricToggle"> Metric mode
+        </label>
 
         <main class="layout">
             <section class="inputs-column">

--- a/src/config/sizeOptions.js
+++ b/src/config/sizeOptions.js
@@ -1,13 +1,13 @@
 // sizeOptions.js
 
 // ===== Constants =====
-export const SIZE_OPTIONS = {
+export const INCH_SIZE_OPTIONS = {
     sheet: [
         { width: 12, length: 18, name: "Tabloid Extra" },
         { width: 13, length: 19, name: "Super B" },
         { width: 8.5, length: 11, name: "Letter" },
         { width: 9, length: 12, name: "Letter Plus" },
-        { width: 10, length: 13, name: "Letter Plus Plus"},
+        { width: 10, length: 13, name: "Letter Plus Plus" },
         { width: 11.5, length: 17.5, name: "Hemp Paper" },
         { width: 11, length: 17, name: "Tabloid" },
         { width: 14.66, length: 25, name: "Awful Oversize" }
@@ -19,20 +19,55 @@ export const SIZE_OPTIONS = {
         { width: 5, length: 7, name: "5x7" },
         { width: 5.5, length: 8.5, name: "Half Letter" },
         { width: 6, length: 9, name: "Sunrun Postcard" },
-        { width: 4, length: 6, name: "Chipotle" },
+        { width: 4, length: 6, name: "Chipotle" }
     ],
     gutter: [
         { width: 0.125, length: 0.125, name: "1/8" },
         { width: 0.25, length: 0.25, name: "1/4" },
         { width: 0, length: 0, name: "No Gutter" },
         { width: 0.3125, length: 0.17, name: "Duplo 25 UP" }
-
     ],
     margin: [
         { width: 0.0625, length: 0.0625, name: "1/16" },
         { width: 0.25, length: 0.25, name: "1/4" },
         { width: 0.5, length: 0.5, name: "1/2" },
         { width: 0, length: 0, name: "No Margin" },
-        { width: 0.125, length: 0.125, name: "1/8" },
+        { width: 0.125, length: 0.125, name: "1/8" }
+    ]
+};
+
+// Metric equivalents in millimeters
+export const MM_SIZE_OPTIONS = {
+    sheet: [
+        { width: 305, length: 457, name: "Tabloid Extra" },
+        { width: 330, length: 483, name: "Super B" },
+        { width: 216, length: 279, name: "Letter" },
+        { width: 229, length: 305, name: "Letter Plus" },
+        { width: 254, length: 330, name: "Letter Plus Plus" },
+        { width: 292, length: 445, name: "Hemp Paper" },
+        { width: 279, length: 432, name: "Tabloid" },
+        { width: 372, length: 635, name: "Awful Oversize" }
+    ],
+    doc: [
+        { width: 89, length: 102, name: "Folded Business Card" },
+        { width: 108, length: 279, name: "Door Hanger" },
+        { width: 108, length: 140, name: "Quarter Letter" },
+        { width: 127, length: 178, name: "5x7" },
+        { width: 140, length: 216, name: "Half Letter" },
+        { width: 152, length: 229, name: "Sunrun Postcard" },
+        { width: 102, length: 152, name: "Chipotle" }
+    ],
+    gutter: [
+        { width: 3, length: 3, name: "1/8" },
+        { width: 6, length: 6, name: "1/4" },
+        { width: 0, length: 0, name: "No Gutter" },
+        { width: 8, length: 4, name: "Duplo 25 UP" }
+    ],
+    margin: [
+        { width: 2, length: 2, name: "1/16" },
+        { width: 6, length: 6, name: "1/4" },
+        { width: 13, length: 13, name: "1/2" },
+        { width: 0, length: 0, name: "No Margin" },
+        { width: 3, length: 3, name: "1/8" }
     ]
 };

--- a/src/layout/layoutController.js
+++ b/src/layout/layoutController.js
@@ -52,7 +52,8 @@ export function drawLayoutWrapper(layout, scorePositions = [], elements) {
 
 export function displayProgramSequence(layout, elements) {
     const sequence = calcSequence(layout);
-    renderProgramSequence(sequence, elements.programSequence);
+    const unit = elements.metricToggle && elements.metricToggle.checked ? 'mm' : 'inches';
+    renderProgramSequence(sequence, elements.programSequence, unit);
 }
 
 export function updateLayoutInfo(layout, elements) {
@@ -67,24 +68,42 @@ export function updateLayoutInfo(layout, elements) {
     elements.wasteLegend.textContent = `Waste: ${waste}%`;
 }
 
-export function setDefaultValues(elements) {
-    elements.sheetWidth.value = "12.0";
-    elements.sheetLength.value = "18.0";
-    elements.docWidth.value = "3.5";
-    elements.docLength.value = "4.0";
-    elements.gutterWidth.value = "0.125";
-    elements.gutterLength.value = "0.125";
-    elements.marginWidth.value = "0.25";
-    elements.marginLength.value = "0.25";
+export function setDefaultValues(elements, isMetric = false) {
+    if (isMetric) {
+        elements.sheetWidth.value = "305";
+        elements.sheetLength.value = "457";
+        elements.docWidth.value = "89";
+        elements.docLength.value = "102";
+        elements.gutterWidth.value = "3";
+        elements.gutterLength.value = "3";
+        elements.marginWidth.value = "6";
+        elements.marginLength.value = "6";
+    } else {
+        elements.sheetWidth.value = "12.0";
+        elements.sheetLength.value = "18.0";
+        elements.docWidth.value = "3.5";
+        elements.docLength.value = "4.0";
+        elements.gutterWidth.value = "0.125";
+        elements.gutterLength.value = "0.125";
+        elements.marginWidth.value = "0.25";
+        elements.marginLength.value = "0.25";
+    }
 }
 
-export function selectDefaultSizes(elements) {
-    const defaultSelections = {
-        sheet: { width: 12, length: 18 },
-        doc: { width: 3.5, length: 4 },
-        gutter: { width: 0.125, length: 0.125 },
-        margin: { width: 0.25, length: 0.25 }
-    };
+export function selectDefaultSizes(elements, isMetric = false) {
+    const defaultSelections = isMetric
+        ? {
+              sheet: { width: 305, length: 457 },
+              doc: { width: 89, length: 102 },
+              gutter: { width: 3, length: 3 },
+              margin: { width: 6, length: 6 }
+          }
+        : {
+              sheet: { width: 12, length: 18 },
+              doc: { width: 3.5, length: 4 },
+              gutter: { width: 0.125, length: 0.125 },
+              margin: { width: 0.25, length: 0.25 }
+          };
 
     Object.entries(defaultSelections).forEach(([type, { width, length }]) => {
         const container = elements[`${type}Buttons`];

--- a/src/scoring/scoreController.js
+++ b/src/scoring/scoreController.js
@@ -1,4 +1,4 @@
-import { calculateScorePositions } from './scoring.js';
+import { calculateScorePositions, FOLD_ALLOWANCE_INCH, FOLD_ALLOWANCE_MM } from './scoring.js';
 import { renderScorePositions } from '../ui/display.js';
 import { calculateLayoutDetails, drawLayoutWrapper } from '../layout/layoutController.js';
 
@@ -16,7 +16,8 @@ export function calculateScores(elements) {
             .filter(n => !isNaN(n));
     }
 
-    const scorePositions = calculateScorePositions(layout, foldType, custom);
+    const allowance = elements.metricToggle.checked ? FOLD_ALLOWANCE_MM : FOLD_ALLOWANCE_INCH;
+    const scorePositions = calculateScorePositions(layout, foldType, custom, allowance);
     lastScorePositions = scorePositions;
 
     drawLayoutWrapper(layout, elements.showScores.checked ? scorePositions : [], elements);
@@ -24,7 +25,8 @@ export function calculateScores(elements) {
 }
 
 export function displayScorePositions(scorePositions, elements) {
-    renderScorePositions(scorePositions, elements.scorePositions);
+    const unit = elements.metricToggle.checked ? 'mm' : 'inches';
+    renderScorePositions(scorePositions, elements.scorePositions, unit);
 }
 
 export function getLastScorePositions() {

--- a/src/scoring/scoring.js
+++ b/src/scoring/scoring.js
@@ -1,9 +1,10 @@
 // scoring.js
 // Functions related to scoring positions and other scoring utilities
 
-// Default allowance (in inches) to compensate for paper thickness when folding.
-// Thicker paper stocks may require a larger allowance to prevent overlapping folds.
-export const FOLD_ALLOWANCE = 0.05;
+// Default allowance to compensate for paper thickness when folding.
+// Values are provided for both inches and millimeters.
+export const FOLD_ALLOWANCE_INCH = 0.05;
+export const FOLD_ALLOWANCE_MM = 1.27;
 
 // Supported fold types for calculating score positions
 const SUPPORTED_FOLD_TYPES = ['bifold', 'trifold', 'gatefold', 'custom'];
@@ -20,7 +21,7 @@ export function calculateScorePositions(
     layout,
     foldType = 'bifold',
     customPositions = [],
-    allowance = FOLD_ALLOWANCE
+    allowance = FOLD_ALLOWANCE_INCH
 ) {
     if (!SUPPORTED_FOLD_TYPES.includes(foldType)) {
         throw new Error(`Unsupported fold type: ${foldType}`);

--- a/src/ui/display.js
+++ b/src/ui/display.js
@@ -1,4 +1,4 @@
-export function renderProgramSequence(sequence, container) {
+export function renderProgramSequence(sequence, container, unit = 'inches') {
     container.innerHTML = `
         <div class="card-header">
             <h2>Program Sequence</h2>
@@ -12,7 +12,7 @@ export function renderProgramSequence(sequence, container) {
             ${sequence.map((cut, index) => `
                 <tr>
                     <td>${index + 1}</td>
-                    <td>${cut.toFixed(3)} inches</td>
+                    <td>${cut.toFixed(3)} ${unit}</td>
                 </tr>
             `).join('')}
             </tbody>
@@ -25,7 +25,7 @@ export function renderProgramSequence(sequence, container) {
     });
 }
 
-export function renderScorePositions(scorePositions, container) {
+export function renderScorePositions(scorePositions, container, unit = 'inches') {
     // Render score measurements into the nested #scorePositions div
     container.innerHTML = `
         <div class="score-header">
@@ -34,7 +34,7 @@ export function renderScorePositions(scorePositions, container) {
         </div>
         <table>
             <thead>
-                <tr><th>Score Position (inches)</th></tr>
+                <tr><th>Score Position (${unit})</th></tr>
             </thead>
             <tbody>
             ${scorePositions.map(pos => `<tr><td>${pos.y.toFixed(3)}</td></tr>`).join('')}

--- a/src/ui/elements.js
+++ b/src/ui/elements.js
@@ -45,5 +45,6 @@ export const elements = {
     customScoreInputs: document.getElementById('customScoreInputs'),
     customScores: document.getElementById('customScores'),
     calculateScoresButton: document.getElementById('calculateScoresButton'),
-    themeToggle: document.getElementById('themeToggle')
+    themeToggle: document.getElementById('themeToggle'),
+    metricToggle: document.getElementById('metricToggle')
 };

--- a/src/ui/events.js
+++ b/src/ui/events.js
@@ -1,5 +1,6 @@
 import { calculateLayout, calculateLayoutDetails, drawLayoutWrapper, zoomIn, zoomOut, resetZoom } from '../layout/layoutController.js';
 import { calculateScores, getLastScorePositions, clearScoreData } from '../scoring/scoreController.js';
+import { toggleMetricMode } from './metricToggle.js';
 
 export function registerEventListeners(elements) {
     elements.sheetButtons.addEventListener('click', event => handleSizeButtonClick(event, elements));
@@ -7,11 +8,13 @@ export function registerEventListeners(elements) {
     elements.gutterButtons.addEventListener('click', event => handleSizeButtonClick(event, elements));
     elements.marginButtons.addEventListener('click', event => handleSizeButtonClick(event, elements));
 
-    const customMarginButton = document.getElementById('customMarginSizeButton');
     ['marginWidth', 'marginLength'].forEach(id => {
         elements[id].addEventListener('input', () => {
+            const customMarginButton = document.getElementById('customMarginSizeButton');
             elements.marginButtons.querySelectorAll('button').forEach(btn => btn.classList.remove('active'));
-            customMarginButton.classList.add('active');
+            if (customMarginButton) {
+                customMarginButton.classList.add('active');
+            }
             elements.marginInputs.classList.remove('hidden');
             calculateLayout(elements, getLastScorePositions(), () => clearScoreData(elements));
         });
@@ -35,6 +38,8 @@ export function registerEventListeners(elements) {
     });
     elements.rotateDocsButton.addEventListener('click', () => rotateSize('doc', elements));
     elements.rotateSheetButton.addEventListener('click', () => rotateSize('sheet', elements));
+
+    elements.metricToggle.addEventListener('change', () => toggleMetricMode(elements));
 
     const inputIds = ['sheetWidth', 'sheetLength', 'docWidth', 'docLength', 'gutterWidth', 'gutterLength', 'marginWidth', 'marginLength'];
     inputIds.forEach(id => {

--- a/src/ui/metricToggle.js
+++ b/src/ui/metricToggle.js
@@ -1,0 +1,50 @@
+import { createSizeButtons } from './buttonCreation.js';
+import { INCH_SIZE_OPTIONS, MM_SIZE_OPTIONS } from '../config/sizeOptions.js';
+import { setDefaultValues, selectDefaultSizes, calculateLayout } from '../layout/layoutController.js';
+
+function updateSteps(elements, isMetric) {
+    const largeStep = isMetric ? 1 : 0.25;
+    const smallStep = isMetric ? 1 : 0.125;
+    ['sheetWidth','sheetLength','docWidth','docLength'].forEach(id => {
+        elements[id].step = largeStep;
+    });
+    ['gutterWidth','gutterLength','marginWidth','marginLength'].forEach(id => {
+        elements[id].step = smallStep;
+    });
+}
+
+function updateUnitLabels(isMetric) {
+    const unit = isMetric ? 'mm' : 'in';
+    const ids = ['sheetWidth','sheetLength','docWidth','docLength','gutterWidth','gutterLength','marginWidth','marginLength','customScores'];
+    ids.forEach(id => {
+        const label = document.querySelector(`label[for="${id}"]`);
+        if (label) {
+            label.textContent = label.textContent
+                .replace('(in', `(${unit}`)
+                .replace('(mm', `(${unit}`);
+        }
+    });
+}
+
+export function toggleMetricMode(elements) {
+    const isMetric = elements.metricToggle.checked;
+    const options = isMetric ? MM_SIZE_OPTIONS : INCH_SIZE_OPTIONS;
+
+    elements.sheetButtons.innerHTML = '';
+    elements.docButtons.innerHTML = '';
+    elements.gutterButtons.innerHTML = '';
+    elements.marginButtons.innerHTML = '';
+
+    createSizeButtons({
+        sheetButtons: elements.sheetButtons,
+        docButtons: elements.docButtons,
+        gutterButtons: elements.gutterButtons,
+        marginButtons: elements.marginButtons
+    }, options);
+
+    setDefaultValues(elements, isMetric);
+    selectDefaultSizes(elements, isMetric);
+    updateUnitLabels(isMetric);
+    updateSteps(elements, isMetric);
+    calculateLayout(elements);
+}


### PR DESCRIPTION
## Summary
- add metric mode toggle to UI
- support metric presets and defaults for sheet, document, gutter, and margin sizes
- show layout and scoring values in selected unit

## Testing
- `node tests/calculateAdaptiveScale.test.js`
- `node tests/calculations.test.js`
- `node tests/drawLayout.test.js`
- `node tests/scoreLines.test.js`
- `node tests/scoring.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a937b86ccc83249d635b76559ad073