### PR TITLE
Refine mobile header and theme toggle

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,10 +1,11 @@
 import { elements } from './src/ui/elements.js';
-import { registerEventListeners } from './src/ui/events.js';
+import { registerEventListeners, initTheme } from './src/ui/events.js';
 import { setDefaultValues, selectDefaultSizes, calculateLayout } from './src/layout/layoutController.js';
 import { createSizeButtons } from './src/ui/buttonCreation.js';
 import { INCH_SIZE_OPTIONS } from './src/config/sizeOptions.js';
 
 function init() {
+    initTheme(elements);
     createSizeButtons({
         sheetButtons: elements.sheetButtons,
         docButtons: elements.docButtons,

--- a/index.html
+++ b/index.html
@@ -10,8 +10,10 @@
 </head>
 <body>
     <div class="container">
-        <h1>Kev's Bitchin' Print Calculator</h1>
-        <button id="themeToggle" class="btn btn-secondary theme-toggle">Toggle Dark Mode</button>
+        <header class="header">
+            <h1>Kev's Bitchin' Print Calculator</h1>
+            <button id="themeToggle" class="theme-toggle" aria-label="Toggle dark mode">🌙</button>
+        </header>
         <label for="metricToggle" class="checkbox-label">
             <input type="checkbox" id="metricToggle"> Metric mode
         </label>

--- a/src/ui/events.js
+++ b/src/ui/events.js
@@ -59,6 +59,7 @@ export function registerEventListeners(elements) {
     elements.themeToggle.addEventListener('click', () => toggleTheme(elements));
 
     toggleCustomInputs(elements);
+    updateThemeIcon(elements);
 }
 
 function handleSizeButtonClick(event, elements) {
@@ -99,15 +100,32 @@ function rotateSize(type, elements, shouldCalculate = true) {
     }
 }
 
+export function initTheme(elements) {
+    const savedTheme = localStorage.getItem('theme');
+    if (savedTheme === 'dark') {
+        document.documentElement.setAttribute('data-theme', 'dark');
+    }
+    updateThemeIcon(elements);
+}
+
 function toggleTheme(elements) {
     const root = document.documentElement;
-    if (root.getAttribute('data-theme') === 'dark') {
+    const isDark = root.getAttribute('data-theme') === 'dark';
+    if (isDark) {
         root.removeAttribute('data-theme');
+        localStorage.setItem('theme', 'light');
     } else {
         root.setAttribute('data-theme', 'dark');
+        localStorage.setItem('theme', 'dark');
     }
+    updateThemeIcon(elements);
     const layout = calculateLayoutDetails(elements);
     drawLayoutWrapper(layout, elements.showScores.checked ? getLastScorePositions() : [], elements);
+}
+
+function updateThemeIcon(elements) {
+    const isDark = document.documentElement.getAttribute('data-theme') === 'dark';
+    elements.themeToggle.textContent = isDark ? '☀️' : '🌙';
 }
 
 function toggleCustomInputs(elements) {

--- a/styles/base.css
+++ b/styles/base.css
@@ -61,15 +61,32 @@ body {
 
 /* Typography */
 h1 {
-    font-size: 28px;
-    text-align: center;
-    margin: 0 0 16px 0;
-    padding: 8px;
+    font-size: 24px;
+    margin: 0;
+}
+
+.header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 8px 16px;
     background-color: var(--card);
-    color: var(--ink);
     position: sticky;
     top: 0;
     z-index: 10;
+}
+
+.theme-toggle {
+    background: none;
+    border: none;
+    font-size: 24px;
+    cursor: pointer;
+    color: var(--ink);
+}
+
+.theme-toggle:focus-visible {
+    outline: 2px solid var(--blue);
+    outline-offset: 2px;
 }
 
 h2 {

--- a/styles/components.css
+++ b/styles/components.css
@@ -72,9 +72,8 @@
 }
 
 .visualizer-options {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
     gap: 8px;
     margin-bottom: 16px;
 }
@@ -133,9 +132,6 @@
     font: inherit;
 }
 
-.btn.theme-toggle {
-    width: auto;
-}
 
 .btn .icon {
     line-height: 1;
@@ -291,4 +287,8 @@ tbody tr:nth-child(even) {
 .legend-line.score {
     border-top-style: dashed;
     border-color: rgb(var(--score-color));
+}
+
+.visualizer-column.card {
+    border-top: 4px solid var(--blue);
 }


### PR DESCRIPTION
## Summary
- Replace large theme button with compact icon in sticky header and persist user preference
- Improve visual hierarchy of layout card and options

## Testing
- `for file in tests/*.test.js; do echo Running $file; node $file; done`

------
https://chatgpt.com/codex/tasks/task_e_68a938abf3c08324a47af34464bf22e8