### PR TITLE
Add unified toggle menu for theme and metric modes

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,11 +12,18 @@
     <div class="container">
         <header class="header">
             <h1>Kev's Bitchin' Print Calculator</h1>
-            <button id="themeToggle" class="theme-toggle" aria-label="Toggle dark mode">🌙</button>
+            <div class="menu-bar">
+                <label class="switch">
+                    <input type="checkbox" id="themeToggle" aria-label="Toggle dark mode">
+                    <span class="slider"></span>
+                </label>
+                <label class="switch">
+                    <input type="checkbox" id="metricToggle" aria-label="Toggle metric mode">
+                    <span class="slider"></span>
+                    <span class="switch-text">Metric</span>
+                </label>
+            </div>
         </header>
-        <label for="metricToggle" class="checkbox-label">
-            <input type="checkbox" id="metricToggle"> Metric mode
-        </label>
 
         <main class="layout">
             <section class="inputs-column">

--- a/src/ui/events.js
+++ b/src/ui/events.js
@@ -56,10 +56,9 @@ export function registerEventListeners(elements) {
         });
     });
 
-    elements.themeToggle.addEventListener('click', () => toggleTheme(elements));
+    elements.themeToggle.addEventListener('change', () => toggleTheme(elements));
 
     toggleCustomInputs(elements);
-    updateThemeIcon(elements);
 }
 
 function handleSizeButtonClick(event, elements) {
@@ -104,28 +103,21 @@ export function initTheme(elements) {
     const savedTheme = localStorage.getItem('theme');
     if (savedTheme === 'dark') {
         document.documentElement.setAttribute('data-theme', 'dark');
+        elements.themeToggle.checked = true;
     }
-    updateThemeIcon(elements);
 }
 
 function toggleTheme(elements) {
     const root = document.documentElement;
-    const isDark = root.getAttribute('data-theme') === 'dark';
-    if (isDark) {
-        root.removeAttribute('data-theme');
-        localStorage.setItem('theme', 'light');
-    } else {
+    if (elements.themeToggle.checked) {
         root.setAttribute('data-theme', 'dark');
         localStorage.setItem('theme', 'dark');
+    } else {
+        root.removeAttribute('data-theme');
+        localStorage.setItem('theme', 'light');
     }
-    updateThemeIcon(elements);
     const layout = calculateLayoutDetails(elements);
     drawLayoutWrapper(layout, elements.showScores.checked ? getLastScorePositions() : [], elements);
-}
-
-function updateThemeIcon(elements) {
-    const isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-    elements.themeToggle.textContent = isDark ? '☀️' : '🌙';
 }
 
 function toggleCustomInputs(elements) {

--- a/styles/base.css
+++ b/styles/base.css
@@ -76,19 +76,6 @@ h1 {
     z-index: 10;
 }
 
-.theme-toggle {
-    background: none;
-    border: none;
-    font-size: 24px;
-    cursor: pointer;
-    color: var(--ink);
-}
-
-.theme-toggle:focus-visible {
-    outline: 2px solid var(--blue);
-    outline-offset: 2px;
-}
-
 h2 {
     font-size: 20px;
     margin: 16px 0 8px 0;

--- a/styles/components.css
+++ b/styles/components.css
@@ -210,6 +210,60 @@ select {
     height: auto;
 }
 
+/* Toggle switches used in the menu bar */
+.menu-bar {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+}
+
+.switch {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.switch-text {
+    font-size: 14px;
+}
+
+.switch input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+
+.switch .slider {
+    position: relative;
+    width: 40px;
+    height: 24px;
+    background-color: var(--border);
+    border-radius: 24px;
+    transition: background-color 0.2s;
+    cursor: pointer;
+}
+
+.switch .slider::before {
+    content: '';
+    position: absolute;
+    width: 20px;
+    height: 20px;
+    left: 2px;
+    top: 2px;
+    background-color: var(--card);
+    border-radius: 50%;
+    transition: transform 0.2s;
+}
+
+.switch input:checked + .slider {
+    background-color: var(--blue);
+}
+
+.switch input:checked + .slider::before {
+    transform: translateX(16px);
+}
+
 /* Table Styles */
 table {
     width: 100%;


### PR DESCRIPTION
## Summary
- Group dark theme and metric mode controls in a new top menu bar
- Style both controls as matching toggle switches
- Update theme handling to use checkbox state and clean up old button code

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68a93f039c188324bf04c5eaa79f9bf3