### PR TITLE
Refactor scoring controls layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -149,9 +149,11 @@
 
                 <!-- Score options card now contains score positions -->
                 <section id="scoreOptions" class="card data-card">
-                    <h2>Scoring</h2>
-                    <!-- Score options controls -->
-                    <div class="form-grid">
+                    <div class="card-header">
+                        <h2>Scoring</h2>
+                        <button type="button" id="calculateScoresButton" class="btn btn-primary">Calculate Scores</button>
+                    </div>
+                    <div id="scoreControls" class="form-grid">
                         <label for="foldType">Score Type:</label>
                         <select id="foldType">
                             <option value="bifold">Bifold</option>
@@ -163,9 +165,7 @@
                             <label for="customScores">Custom Positions (in, comma-separated)</label>
                             <input type="text" id="customScores" placeholder="e.g., 2,4.5">
                         </div>
-                        <button type="button" id="calculateScoresButton" class="btn btn-primary">Calculate Scores</button>
                     </div>
-                    <!-- Nested container for score position output -->
                     <div id="scorePositions" role="status" aria-live="polite"></div>
                 </section>
             </aside>

--- a/src/scoring/scoreController.js
+++ b/src/scoring/scoreController.js
@@ -5,13 +5,14 @@ import { calculateLayoutDetails, drawLayoutWrapper } from '../layout/layoutContr
 let lastScorePositions = [];
 
 export function calculateScores(elements) {
-    const foldType = elements.foldType.value;
+    const foldType = elements.scoreControls.querySelector('#foldType').value;
     const layout = calculateLayoutDetails(elements);
 
     let custom = [];
     if (foldType === 'custom') {
-        custom = elements.customScores.value
-            .split(',')
+        custom = elements.scoreControls
+            .querySelector('#customScores')
+            .value.split(',')
             .map(n => parseFloat(n.trim()))
             .filter(n => !isNaN(n));
     }

--- a/src/ui/elements.js
+++ b/src/ui/elements.js
@@ -41,6 +41,7 @@ export const elements = {
     showDocNumbers: document.getElementById('showDocNumbers'),
     showPrintableArea: document.getElementById('showPrintableArea'),
     showMargins: document.getElementById('showMargins'),
+    scoreControls: document.getElementById('scoreControls'),
     foldType: document.getElementById('foldType'),
     customScoreInputs: document.getElementById('customScoreInputs'),
     customScores: document.getElementById('customScores'),

--- a/styles/components.css
+++ b/styles/components.css
@@ -21,6 +21,16 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
+    margin-bottom: 16px;
+}
+
+#scoreControls {
+    margin-bottom: 16px;
+}
+
+#scorePositions {
+    border-top: 1px solid var(--border);
+    padding-top: 16px;
 }
 
 /* Sub-header within #scoreOptions for score measurements */


### PR DESCRIPTION
## Summary
- group scoring header and action button inside a dedicated card header
- organize scoring inputs under new scoreControls container and separate results section
- style header, controls, and results for clear separation and adapt controller to new structure

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68a972282d98832497377c8300ffb6fd