### PR TITLE
Display step numbers for score positions

### DIFF
--- a/src/ui/display.js
+++ b/src/ui/display.js
@@ -29,21 +29,29 @@ export function renderScorePositions(scorePositions, container, unit = 'inches')
     // Render score measurements into the nested #scorePositions div
     container.innerHTML = `
         <div class="score-header">
-            <h3>Score Measurements</h3>
-            <button type="button" class="copy-btn" aria-label="Copy Score Measurements">Copy</button>
+            <h3>Score Positions</h3>
+            <button type="button" class="copy-btn" aria-label="Copy Score Positions">Copy</button>
         </div>
         <table>
             <thead>
-                <tr><th>Score Position (${unit})</th></tr>
+                <tr><th>Step</th><th>Score Position (${unit})</th></tr>
             </thead>
             <tbody>
-            ${scorePositions.map(pos => `<tr><td>${pos.y.toFixed(3)}</td></tr>`).join('')}
+            ${scorePositions.map((pos, index) => `
+                <tr>
+                    <td>${index + 1}</td>
+                    <td>${pos.y.toFixed(3)} ${unit}</td>
+                </tr>
+            `).join('')}
             </tbody>
         </table>
     `;
     const copyBtn = container.querySelector('.copy-btn');
     copyBtn.addEventListener('click', () => {
-        const text = container.querySelector('table').innerText;
+        const rows = Array.from(container.querySelectorAll('tbody tr'))
+            .map(row => Array.from(row.children).map(cell => cell.innerText).join('\t'));
+        const header = ['Step', `Score Position (${unit})`].join('\t');
+        const text = [header, ...rows].join('\n');
         navigator.clipboard.writeText(text);
     });
 }

--- a/styles/components.css
+++ b/styles/components.css
@@ -305,6 +305,12 @@ tbody tr:nth-child(even) {
     background-color: var(--bg);
 }
 
+/* Ensure consistent width for step columns in data tables */
+#programSequence table td:first-child,
+#scorePositions table td:first-child {
+    width: 4ch;
+}
+
 /* Legend styles */
 .legend {
     display: flex;


### PR DESCRIPTION
## Summary
- Render score positions in a two-column table mirroring the Program Sequence table
- Add copy-to-clipboard support for the new table format
- Ensure step columns have a consistent width in program sequence and score tables

## Testing
- `node tests/calculateAdaptiveScale.test.js`
- `node tests/calculations.test.js`
- `node tests/drawLayout.test.js`
- `node tests/scoreLines.test.js`
- `node tests/scoring.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a97e5a52748324a6cac7d20208d15c