### PR TITLE
Move rotate controls into dimension card headers

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,13 @@
             <section class="inputs-column">
                 <form>
                     <section class="dimensions-section card">
-                        <h2>Sheet Dimensions</h2>
+                        <div class="card-header">
+                            <h2>Sheet Dimensions</h2>
+                            <button type="button" id="rotateSheetButton" class="btn btn-tertiary" aria-label="Rotate sheet" aria-describedby="tip-rotate-sheet">
+                                <span class="icon" aria-hidden="true">↻</span>
+                                <span role="tooltip" id="tip-rotate-sheet" class="tooltip">Rotate sheet</span>
+                            </button>
+                        </div>
                         <div class="button-grid" id="sheetButtonsContainer" role="toolbar" aria-label="Sheet size presets"></div>
                         <div class="input-group hidden form-grid" id="sheetDimensionsInputs">
                             <label for="sheetWidth">Width (in)</label>
@@ -41,7 +47,13 @@
                     </section>
 
                     <section class="dimensions-section card">
-                        <h2>Document Dimensions</h2>
+                        <div class="card-header">
+                            <h2>Document Dimensions</h2>
+                            <button type="button" id="rotateDocsButton" class="btn btn-tertiary" aria-label="Rotate documents" aria-describedby="tip-rotate-docs">
+                                <span class="icon" aria-hidden="true">↺</span>
+                                <span role="tooltip" id="tip-rotate-docs" class="tooltip">Rotate documents</span>
+                            </button>
+                        </div>
                         <div class="button-grid" id="docButtonsContainer" role="toolbar" aria-label="Document size presets"></div>
                         <div class="input-group hidden form-grid" id="docDimensionsInputs">
                             <label for="docWidth">Width (in)</label>
@@ -78,7 +90,7 @@
             <section class="visualizer-column card">
                 <h2>Layout Visualizer</h2>
                 <ul class="legend" id="layoutTitle" aria-label="Layout title"></ul>
-                <div class="toolbar" role="toolbar" aria-label="Canvas controls">
+                    <div class="toolbar" role="toolbar" aria-label="Canvas controls">
                     <button type="button" id="fitSheetButton" class="btn btn-tertiary" aria-label="Fit sheet" aria-describedby="tip-fit">
                         <span class="icon" aria-hidden="true">⤢</span>
                         <span role="tooltip" id="tip-fit" class="tooltip">Fit sheet</span>
@@ -94,16 +106,6 @@
                     <button type="button" id="resetViewButton" class="btn btn-tertiary" aria-label="Reset view" aria-describedby="tip-reset">
                         <span class="icon" aria-hidden="true">⟲</span>
                         <span role="tooltip" id="tip-reset" class="tooltip">Reset view</span>
-                    </button>
-                    <button type="button" id="rotateDocsButton" class="btn btn-tertiary" aria-label="Rotate documents" aria-describedby="tip-rotate-docs">
-                        <span class="icon" aria-hidden="true">↺</span>
-                        <span class="label">Docs</span>
-                        <span role="tooltip" id="tip-rotate-docs" class="tooltip">Rotate documents</span>
-                    </button>
-                    <button type="button" id="rotateSheetButton" class="btn btn-tertiary" aria-label="Rotate sheet" aria-describedby="tip-rotate-sheet">
-                        <span class="icon" aria-hidden="true">↻</span>
-                        <span class="label">Sheet</span>
-                        <span role="tooltip" id="tip-rotate-sheet" class="tooltip">Rotate sheet</span>
                     </button>
                 </div>
                 <div class="visualizer-options">

--- a/styles/components.css
+++ b/styles/components.css
@@ -21,7 +21,17 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
+    gap: 8px;
     margin-bottom: 16px;
+}
+
+.card-header h2 {
+    margin: 0;
+}
+
+.card-header .btn {
+    width: auto;
+    flex-shrink: 0;
 }
 
 #scoreControls {


### PR DESCRIPTION
## Summary
- Embed rotate sheet and document controls within their respective dimension cards
- Clean up layout visualizer toolbar by removing rotate buttons
- Adjust card-header styles for proper button alignment

## Testing
- `for f in tests/*.test.js; do node "$f"; done`


------
https://chatgpt.com/codex/tasks/task_e_68ac9642cbc8832484fd37a3b6310b5f