### PR TITLE
Use flex layout for visualizer options

### DIFF
--- a/styles/components.css
+++ b/styles/components.css
@@ -92,10 +92,11 @@
 }
 
 .visualizer-options {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    display: flex;
+    flex-wrap: nowrap;
     gap: 8px;
     margin-bottom: 16px;
+    overflow-x: auto;
 }
 
 .toolbar .btn {


### PR DESCRIPTION
## Summary
- keep visualizer option checkboxes on a single line with a flex layout and horizontal scroll overflow

## Testing
- `node tests/calculateAdaptiveScale.test.js`
- `node tests/calculations.test.js`
- `node tests/drawLayout.test.js`
- `node tests/scoreLines.test.js`
- `node tests/scoring.test.js`
- `node verify-align.js`

------
https://chatgpt.com/codex/tasks/task_e_68ac97554e148324a245eedc6bc86692