### PR TITLE
Use icons for theme and metric toggles

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,13 +15,13 @@
             <div class="menu-bar">
                 <label class="switch">
                     <input type="checkbox" id="themeToggle" aria-label="Toggle dark mode">
-                    <span class="switch-text">Dark Mode</span>
+                    <span class="switch-icon" aria-hidden="true">🌙</span>
                     <span class="slider"></span>
                 </label>
                 <label class="switch">
                     <input type="checkbox" id="metricToggle" aria-label="Toggle metric mode">
                     <span class="slider"></span>
-                    <span class="switch-text">Metric</span>
+                    <span class="switch-icon" aria-hidden="true">📏</span>
                 </label>
             </div>
         </header>

--- a/styles/components.css
+++ b/styles/components.css
@@ -245,8 +245,13 @@ select {
     gap: 8px;
 }
 
-.switch-text {
-    font-size: 14px;
+.switch-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    font-size: 16px;
 }
 
 .switch input {


### PR DESCRIPTION
## Summary
- replace text toggles with moon and ruler icons
- style new switch-icon and remove switch-text styles

## Testing
- `node tests/calculateAdaptiveScale.test.js`
- `node tests/calculations.test.js`
- `node tests/drawLayout.test.js`
- `node tests/scoreLines.test.js`
- `node tests/scoring.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68ac99a109388324810eb6e2ff8ab28f