### PR TITLE
Add optimal layout search and config return

### DIFF
--- a/tests/optimalLayout.test.js
+++ b/tests/optimalLayout.test.js
@@ -1,0 +1,23 @@
+const assert = require('assert');
+
+(async () => {
+  const { findOptimalLayout } = await import('../src/layout/layoutController.js');
+
+  const elements = {
+    docWidth: { value: '3' },
+    docLength: { value: '4' },
+    gutterWidth: { value: '0' },
+    gutterLength: { value: '0' },
+    marginWidth: { value: '0' },
+    marginLength: { value: '0' }
+  };
+
+  const { layout, config } = findOptimalLayout(elements);
+
+  assert.strictEqual(layout.docsAcross * layout.docsDown, 18, 'Expected 18-up layout');
+  assert.strictEqual(layout.sheetWidth, 13, 'Expected sheet width 13');
+  assert.strictEqual(layout.sheetLength, 19, 'Expected sheet length 19');
+  assert.strictEqual(config.docRotated, true, 'Expected document rotation');
+
+  console.log('All findOptimalLayout tests passed');
+})();


### PR DESCRIPTION
## Summary
- add `findOptimalLayout` helper to evaluate sheet sizes, orientations, and document rotations to maximize layout capacity
- compute optimal layout and return its configuration from `calculateLayout` for UI access
- test optimal layout selection for 12×18 and 13×19 sheets

## Testing
- `for file in tests/*.test.js; do echo "Running $file"; node $file; done`

------
https://chatgpt.com/codex/tasks/task_e_68ad727940948324a7cfc8f61a7b620c