### PR TITLE
feat: refresh theme palette for better contrast

### DIFF
--- a/styles/base.css
+++ b/styles/base.css
@@ -20,11 +20,11 @@
     --shadow-md: 0 2px 4px rgba(0, 0, 0, 0.1);
 
     /* Theme variables */
-    --bg: #C0C0C0;
-    --card: #FFFFFF;
-    --ink: #000000;
-    --border: #808080;
-    --blue: #000080;
+    --bg: #f5f7fa;
+    --card: #ffffff;
+    --ink: #212529;
+    --border: #dee2e6;
+    --blue: #0b5ed7;
     --font-family: 'Tahoma', 'Verdana', sans-serif;
 
     /* Theme colors */
@@ -35,11 +35,11 @@
 }
 
 [data-theme="dark"] {
-    --bg: #000000;
-    --card: #C0C0C0;
-    --ink: #FFFFFF;
-    --border: #808080;
-    --blue: #000080;
+    --bg: #121417;
+    --card: #1e2125;
+    --ink: #f8f9fa;
+    --border: #343a40;
+    --blue: #66b2ff;
 
     /* Theme colors */
     --doc-color: 0, 0, 0;


### PR DESCRIPTION
## Summary
- lighten default theme background and text colors
- introduce brighter accent blue and tweak dark theme for accessible contrast
- verify color contrast ratios for light and dark modes

## Testing
- `for f in tests/*.test.js; do node "$f"; done`
- `node contrast-check.js` *(inline script to compute ratios >4.5)*

------
https://chatgpt.com/codex/tasks/task_e_68ad78fe56a08324881ff1b587775b59