### PR TITLE
Refactor toggles into reusable component

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,18 +18,26 @@
             <!-- Site title and mode toggles -->
             <!-- TODO: Accessibility review and responsive tweaks -->
             <h1>Kev's Bitchin' Print Calculator</h1>
-            <div class="menu-bar">
-                <label class="switch">
-                    <input type="checkbox" id="themeToggle" aria-label="Toggle dark mode">
-                    <span class="slider"></span>
-                    <span class="switch-icon" aria-hidden="true">🌙</span>
-                </label>
-                <label class="switch">
-                    <input type="checkbox" id="metricToggle" aria-label="Toggle metric mode">
-                    <span class="slider"></span>
-                    <span class="switch-icon" aria-hidden="true">📏</span>
-                </label>
-            </div>
+            <div class="menu-bar" id="menuBar"></div>
+            <script type="module">
+                import { createToggleSwitch } from './src/ui/toggles.js';
+
+                const menuBar = document.getElementById('menuBar');
+                menuBar.appendChild(
+                    createToggleSwitch({
+                        id: 'themeToggle',
+                        label: 'Toggle dark mode',
+                        icon: '🌙'
+                    })
+                );
+                menuBar.appendChild(
+                    createToggleSwitch({
+                        id: 'metricToggle',
+                        label: 'Toggle metric mode',
+                        icon: '📏'
+                    })
+                );
+            </script>
         </header>
 
 

--- a/index.html
+++ b/index.html
@@ -19,25 +19,6 @@
             <!-- TODO: Accessibility review and responsive tweaks -->
             <h1>Kev's Bitchin' Print Calculator</h1>
             <div class="menu-bar" id="menuBar"></div>
-            <script type="module">
-                import { createToggleSwitch } from './src/ui/toggles.js';
-
-                const menuBar = document.getElementById('menuBar');
-                menuBar.appendChild(
-                    createToggleSwitch({
-                        id: 'themeToggle',
-                        label: 'Toggle dark mode',
-                        icon: '🌙'
-                    })
-                );
-                menuBar.appendChild(
-                    createToggleSwitch({
-                        id: 'metricToggle',
-                        label: 'Toggle metric mode',
-                        icon: '📏'
-                    })
-                );
-            </script>
         </header>
 
 
@@ -245,6 +226,7 @@
     <!-- ===== Closing Scripts ===== -->
     <!-- Load application modules -->
     <!-- TODO: Bundle and defer non-critical scripts -->
+    <script type="module" src="src/ui/initToggles.js"></script>
     <script type="module" src="app.js"></script>
     <script type="module" src="visualizer.js"></script>
 </body>

--- a/src/ui/initToggles.js
+++ b/src/ui/initToggles.js
@@ -1,0 +1,19 @@
+import { createToggleSwitch } from './toggles.js';
+
+const menuBar = document.getElementById('menuBar');
+
+menuBar.appendChild(
+    createToggleSwitch({
+        id: 'themeToggle',
+        label: 'Toggle dark mode',
+        icon: '🌙'
+    })
+);
+
+menuBar.appendChild(
+    createToggleSwitch({
+        id: 'metricToggle',
+        label: 'Toggle metric mode',
+        icon: '📏'
+    })
+);

--- a/src/ui/toggles.js
+++ b/src/ui/toggles.js
@@ -1,0 +1,23 @@
+export function createToggleSwitch({ id, label, icon }) {
+    const wrapper = document.createElement('label');
+    wrapper.className = 'switch';
+
+    const input = document.createElement('input');
+    input.type = 'checkbox';
+    input.id = id;
+    input.setAttribute('aria-label', label);
+
+    const slider = document.createElement('span');
+    slider.className = 'slider';
+
+    const iconSpan = document.createElement('span');
+    iconSpan.className = 'switch-icon';
+    iconSpan.setAttribute('aria-hidden', 'true');
+    iconSpan.textContent = icon;
+
+    wrapper.appendChild(input);
+    wrapper.appendChild(slider);
+    wrapper.appendChild(iconSpan);
+
+    return wrapper;
+}


### PR DESCRIPTION
## Summary
- add reusable `createToggleSwitch` utility for menu toggles
- render theme and metric toggles via script instead of hard-coded markup

## Testing
- `node tests/calculateAdaptiveScale.test.js`
- `node tests/calculations.test.js`
- `node tests/drawLayout.test.js`
- `node tests/optimalLayout.test.js`
- `node tests/scoreLines.test.js`
- `node tests/scoring.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68ae72780b988324ba425814ad296882