### PR TITLE
Dynamically build visualizer legend and options

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,27 +65,7 @@
                 <button id="optimalLayoutButton" class="btn btn-success hidden">See optimal layout</button>
 
                 <!-- ===== Visualization Options ===== -->
-                <div class="visualizer-options">
-                    <!-- Toggle score line visibility -->
-                    <label for="showScores" class="checkbox-label">
-                        <input type="checkbox" id="showScores"> Display scores
-                    </label>
-
-                    <!-- Toggle document numbers visibility -->
-                    <label for="showDocNumbers" class="checkbox-label">
-                        <input type="checkbox" id="showDocNumbers" checked> Show document numbers
-                    </label>
-
-                    <!-- Toggle printable area visibility -->
-                    <label for="showPrintableArea" class="checkbox-label">
-                        <input type="checkbox" id="showPrintableArea" checked> Show printable area
-                    </label>
-
-                    <!-- Toggle margin visibility -->
-                    <label for="showMargins" class="checkbox-label">
-                        <input type="checkbox" id="showMargins" checked> Show margins
-                    </label>
-                </div>
+                <div class="visualizer-options" id="visualizerOptions"></div>
 
                 <!-- ===== Canvas ===== -->
                 <div class="canvas-wrapper">
@@ -93,25 +73,7 @@
                 </div>
 
                 <!-- ===== Legend ===== -->
-                <ul class="legend" aria-label="Layout legend">
-                    <li class="legend-item">
-                        <span class="legend-swatch doc" aria-hidden="true"></span>
-                        <span>Document</span>
-                    </li>
-                    <li class="legend-item">
-                        <span class="legend-swatch margin" aria-hidden="true"></span>
-                        <span>Margins</span>
-                    </li>
-                    <li class="legend-item">
-                        <span class="legend-swatch printable" aria-hidden="true"></span>
-                        <span>Non-Printable Area</span>
-                    </li>
-                    <li class="legend-item">
-                        <span class="legend-line score" aria-hidden="true"></span>
-                        <span>Score Line</span>
-                    </li>
-                    <li class="legend-item" id="wasteLegend"></li>
-                </ul>
+                <ul class="legend" aria-label="Layout legend" id="visualizerLegend"></ul>
             </section>
 
 
@@ -150,6 +112,7 @@
     <!-- Load application modules -->
     <!-- TODO: Bundle and defer non-critical scripts -->
     <script type="module" src="src/ui/initToggles.js"></script>
+    <script type="module" src="src/ui/renderLegendOptions.js"></script>
     <script type="module" src="app.js"></script>
     <script type="module" src="visualizer.js"></script>
 </body>

--- a/src/config/legendOptions.js
+++ b/src/config/legendOptions.js
@@ -1,11 +1,11 @@
 // legendOptions.js
 
 export const LEGEND_ITEMS = [
-    { className: 'doc', label: 'Document', type: 'swatch' },
-    { className: 'margin', label: 'Margins', type: 'swatch' },
-    { className: 'printable', label: 'Non-Printable Area', type: 'swatch' },
-    { className: 'score', label: 'Score Line', type: 'line' },
-    { id: 'wasteLegend' }
+    { type: 'swatch', className: 'doc', label: 'Document' },
+    { type: 'swatch', className: 'margin', label: 'Margins' },
+    { type: 'swatch', className: 'printable', label: 'Non-Printable Area' },
+    { type: 'line', className: 'score', label: 'Score Line' },
+    { type: 'placeholder', id: 'wasteLegend' }
 ];
 
 export const OPTION_CHECKBOXES = [

--- a/src/config/legendOptions.js
+++ b/src/config/legendOptions.js
@@ -1,0 +1,16 @@
+// legendOptions.js
+
+export const LEGEND_ITEMS = [
+    { className: 'doc', label: 'Document', type: 'swatch' },
+    { className: 'margin', label: 'Margins', type: 'swatch' },
+    { className: 'printable', label: 'Non-Printable Area', type: 'swatch' },
+    { className: 'score', label: 'Score Line', type: 'line' },
+    { id: 'wasteLegend' }
+];
+
+export const OPTION_CHECKBOXES = [
+    { id: 'showScores', label: 'Display scores', checked: false },
+    { id: 'showDocNumbers', label: 'Show document numbers', checked: true },
+    { id: 'showPrintableArea', label: 'Show printable area', checked: true },
+    { id: 'showMargins', label: 'Show margins', checked: true }
+];

--- a/src/ui/renderLegendOptions.js
+++ b/src/ui/renderLegendOptions.js
@@ -1,0 +1,53 @@
+import { LEGEND_ITEMS, OPTION_CHECKBOXES } from '../config/legendOptions.js';
+
+export function renderLegendOptions() {
+    const legendEl = document.getElementById('visualizerLegend');
+    const optionsEl = document.getElementById('visualizerOptions');
+
+    if (legendEl) {
+        LEGEND_ITEMS.forEach(item => {
+            const li = document.createElement('li');
+            li.classList.add('legend-item');
+
+            if (item.id) {
+                li.id = item.id;
+                if (item.label) {
+                    li.textContent = item.label;
+                }
+            } else {
+                const marker = document.createElement('span');
+                marker.classList.add(item.type === 'line' ? 'legend-line' : 'legend-swatch');
+                marker.classList.add(item.className);
+                marker.setAttribute('aria-hidden', 'true');
+                li.appendChild(marker);
+
+                const label = document.createElement('span');
+                label.textContent = item.label;
+                li.appendChild(label);
+            }
+
+            legendEl.appendChild(li);
+        });
+    }
+
+    if (optionsEl) {
+        OPTION_CHECKBOXES.forEach(opt => {
+            const label = document.createElement('label');
+            label.className = 'checkbox-label';
+            label.htmlFor = opt.id;
+
+            const input = document.createElement('input');
+            input.type = 'checkbox';
+            input.id = opt.id;
+            if (opt.checked) {
+                input.checked = true;
+            }
+
+            label.appendChild(input);
+            label.appendChild(document.createTextNode(` ${opt.label}`));
+            optionsEl.appendChild(label);
+        });
+    }
+}
+
+renderLegendOptions();

--- a/src/ui/renderLegendOptions.js
+++ b/src/ui/renderLegendOptions.js
@@ -9,8 +9,10 @@ export function renderLegendOptions() {
             const li = document.createElement('li');
             li.classList.add('legend-item');
 
-            if (item.id) {
-                li.id = item.id;
+            if (item.type === 'placeholder') {
+                if (item.id) {
+                    li.id = item.id;
+                }
                 if (item.label) {
                     li.textContent = item.label;
                 }


### PR DESCRIPTION
## Summary
- Add central config for legend entries and option checkboxes
- Auto-render legend and option controls from config
- Strip hard-coded legend and option markup from index.html

## Testing
- `for f in tests/*.test.js; do node "$f"; done`

------
https://chatgpt.com/codex/tasks/task_e_68ae77dfc81c83249a0ab95c4024f789