### PR TITLE
feat: extract dark theme styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="styles/base.css">
     <link rel="stylesheet" href="styles/layout.css">
     <link rel="stylesheet" href="styles/components.css">
+    <link rel="stylesheet" href="styles/themes/dark.css">
 </head>
 <body>
     <div class="container">

--- a/styles/base.css
+++ b/styles/base.css
@@ -34,19 +34,6 @@
     --score-color: var(--printable-color);
 }
 
-[data-theme="dark"] {
-    --bg: #121417;
-    --card: #1e2125;
-    --ink: #f8f9fa;
-    --border: #343a40;
-    --blue: #66b2ff;
-
-    /* Theme colors */
-    --doc-color: 0, 0, 0;
-    --margin-color: 255, 0, 0;
-    --printable-color: 255, 0, 255;
-    --score-color: var(--printable-color);
-}
 
 /* General Styles */
 body {

--- a/styles/themes/dark.css
+++ b/styles/themes/dark.css
@@ -1,0 +1,13 @@
+[data-theme="dark"] {
+    --bg: #121417;
+    --card: #1e2125;
+    --ink: #f8f9fa;
+    --border: #343a40;
+    --blue: #66b2ff;
+
+    /* Theme colors */
+    --doc-color: 0, 0, 0;
+    --margin-color: 255, 0, 0;
+    --printable-color: 255, 0, 255;
+    --score-color: var(--printable-color);
+}


### PR DESCRIPTION
## Summary
- move dark theme CSS variables into `styles/themes/dark.css`
- keep only light-mode defaults in `styles/base.css`
- load new dark theme stylesheet in `index.html`

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68ae7c73a1888324bdf2bb053f156fd8