### PR TITLE
feat: unify line stroke colors

### DIFF
--- a/src/config/colorConfig.js
+++ b/src/config/colorConfig.js
@@ -4,11 +4,12 @@
 export function getColorTokens() {
     const styles = getComputedStyle(document.documentElement);
     const printable = styles.getPropertyValue('--printable-color').trim();
+    const line = styles.getPropertyValue('--line-color').trim();
     return {
-        document: `rgb(${styles.getPropertyValue('--doc-color').trim()})`,
-        margin: `rgb(${styles.getPropertyValue('--margin-color').trim()})`,
+        document: `rgb(${line})`,
+        margin: `rgb(${line})`,
         printableFill: `rgba(${printable}, 0.25)`,
-        score: `rgb(${styles.getPropertyValue('--score-color').trim()})`,
+        score: `rgb(${line})`,
         label: styles.getPropertyValue('--blue').trim()
     };
 }

--- a/styles/base.css
+++ b/styles/base.css
@@ -12,6 +12,7 @@
  * --margin-color: RGB components for margin areas
  * --printable-color: RGB components for non-printable areas
  * --score-color: RGB components for score lines
+ * --line-color: RGB components for layout lines
  */
 
 :root {
@@ -32,6 +33,7 @@
     --margin-color: 255, 0, 0;
     --printable-color: 255, 0, 255;
     --score-color: var(--printable-color);
+    --line-color: 0, 0, 0;
 }
 
 

--- a/styles/components.css
+++ b/styles/components.css
@@ -363,11 +363,11 @@ tbody tr:nth-child(even) {
 }
 
 .legend-swatch.doc {
-    border-color: rgb(var(--doc-color));
+    border-color: rgb(var(--line-color));
 }
 
 .legend-swatch.margin {
-    border-color: rgb(var(--margin-color));
+    border-color: rgb(var(--line-color));
 }
 
 .legend-swatch.printable {
@@ -383,7 +383,7 @@ tbody tr:nth-child(even) {
 
 .legend-line.score {
     border-top-style: dashed;
-    border-color: rgb(var(--score-color));
+    border-color: rgb(var(--line-color));
 }
 
 .visualizer-column.card {

--- a/styles/themes/dark.css
+++ b/styles/themes/dark.css
@@ -10,4 +10,5 @@
     --margin-color: 255, 0, 0;
     --printable-color: 255, 0, 255;
     --score-color: var(--printable-color);
+    --line-color: 255, 255, 255;
 }


### PR DESCRIPTION
## Summary
- add `--line-color` CSS variable and apply in dark theme
- derive document, margin, and score strokes from `--line-color`
- update legend swatches to use unified line color

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68ae7d43d7048324a967da57f74724e9