### PR TITLE
refactor: unify button styling with theme variables

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,7 +89,7 @@
                 <section id="scoreOptions" class="card data-card">
                     <div class="card-header">
                         <h2>Scoring</h2>
-                        <button type="button" id="calculateScoresButton" class="btn btn-primary">Calculate Scores</button>
+                        <button type="button" id="calculateScoresButton" class="btn">Calculate Scores</button>
                     </div>
                     <div id="scoreControls" class="form-grid">
                         <label for="foldType">Score Type:</label>

--- a/src/ui/display.js
+++ b/src/ui/display.js
@@ -2,7 +2,7 @@ export function renderProgramSequence(sequence, container, unit = 'inches') {
     container.innerHTML = `
         <div class="card-header">
             <h2>Program Sequence</h2>
-            <button type="button" class="copy-btn" aria-label="Copy Program Sequence">Copy</button>
+            <button type="button" class="btn btn-secondary copy-btn" aria-label="Copy Program Sequence">Copy</button>
         </div>
         <table>
             <thead>
@@ -30,7 +30,7 @@ export function renderScorePositions(scorePositions, container, unit = 'inches')
     container.innerHTML = `
         <div class="score-header">
             <h3>Score Positions</h3>
-            <button type="button" class="copy-btn" aria-label="Copy Score Positions">Copy</button>
+            <button type="button" class="btn btn-secondary copy-btn" aria-label="Copy Score Positions">Copy</button>
         </div>
         <table>
             <thead>

--- a/styles/base.css
+++ b/styles/base.css
@@ -26,6 +26,9 @@
     --ink: #212529;
     --border: #dee2e6;
     --blue: #0b5ed7;
+    --button-bg: var(--blue);
+    --button-ink: var(--card);
+    --success: #28a745;
     --font-family: 'Tahoma', 'Verdana', sans-serif;
 
     /* Theme colors */

--- a/styles/components.css
+++ b/styles/components.css
@@ -126,7 +126,6 @@
     opacity: 1;
 }
 
-
 .btn {
     display: inline-flex;
     align-items: center;

--- a/styles/components.css
+++ b/styles/components.css
@@ -138,7 +138,7 @@
     cursor: pointer;
     text-align: center;
     border-radius: 4px;
-    border: 1px solid var(--button-bg);
+    border: 1px solid var(--button-border, var(--button-bg));
     background-color: var(--button-bg);
     color: var(--button-ink);
     font: inherit;

--- a/styles/components.css
+++ b/styles/components.css
@@ -56,18 +56,8 @@
 }
 
 .copy-btn {
-    height: 40px;
+    width: auto;
     padding: 0 8px;
-    border: 1px solid var(--border);
-    background-color: var(--card);
-    border-radius: 4px;
-    cursor: pointer;
-    font: inherit;
-    box-sizing: border-box;
-}
-
-.copy-btn:hover:not([disabled]) {
-    filter: brightness(0.95);
 }
 
 /* Button Styles */
@@ -136,6 +126,7 @@
     opacity: 1;
 }
 
+
 .btn {
     display: inline-flex;
     align-items: center;
@@ -147,9 +138,9 @@
     cursor: pointer;
     text-align: center;
     border-radius: 4px;
-    border: 1px solid transparent;
-    background-color: transparent;
-    color: var(--ink);
+    border: 1px solid var(--button-bg);
+    background-color: var(--button-bg);
+    color: var(--button-ink);
     font: inherit;
 }
 
@@ -158,26 +149,19 @@
     line-height: 1;
 }
 
-.btn-primary {
-    background-color: var(--blue);
-    color: #fff;
-    border-color: var(--blue);
-}
-
 .btn-secondary {
-    background-color: var(--card);
-    border-color: var(--border);
+    --button-bg: var(--card);
+    --button-ink: var(--ink);
 }
 
 .btn-tertiary {
-    background-color: transparent;
-    border-color: transparent;
+    --button-bg: transparent;
+    --button-ink: var(--ink);
 }
 
 .btn-success {
-    background-color: #28a745;
-    border-color: #28a745;
-    color: #fff;
+    --button-bg: var(--success);
+    --button-ink: var(--card);
 }
 
 .btn:hover:not([disabled]) {

--- a/styles/themes/dark.css
+++ b/styles/themes/dark.css
@@ -4,6 +4,9 @@
     --ink: #f8f9fa;
     --border: #343a40;
     --blue: #66b2ff;
+    --button-bg: var(--blue);
+    --button-ink: var(--card);
+    --success: #2ea043;
 
     /* Theme colors */
     --doc-color: 0, 0, 0;


### PR DESCRIPTION
## Summary
- add `--button-bg` and `--button-ink` theme variables with dark theme overrides
- refactor buttons to consume the new variables and drop the unused primary variant
- ensure utility copy buttons use shared `.btn` styling

## Testing
- `for f in tests/*.test.js; do node $f; done`

------
https://chatgpt.com/codex/tasks/task_e_68ae7e1bf73c8324a29d36d7d80dbc70