### PR TITLE
Use patterns for legend icons

### DIFF
--- a/src/config/legendOptions.js
+++ b/src/config/legendOptions.js
@@ -1,10 +1,10 @@
 // legendOptions.js
 
 export const LEGEND_ITEMS = [
-    { type: 'swatch', className: 'doc', label: 'Document' },
+    { type: 'swatch', className: 'doc', label: 'Document outline' },
     { type: 'swatch', className: 'margin', label: 'Margins' },
     { type: 'swatch', className: 'printable', label: 'Non-Printable Area' },
-    { type: 'line', className: 'score', label: 'Score Line' },
+    { type: 'line', className: 'score', label: 'Score Line (dashed)' },
     { type: 'placeholder', id: 'wasteLegend' }
 ];
 

--- a/styles/components.css
+++ b/styles/components.css
@@ -346,16 +346,38 @@ tbody tr:nth-child(even) {
 }
 
 .legend-swatch.doc {
-    border-color: rgb(var(--line-color));
+    border-color: var(--ink);
+    background: repeating-linear-gradient(
+        0deg,
+        var(--ink) 0,
+        var(--ink) 2px,
+        transparent 2px,
+        transparent 4px
+    );
 }
 
 .legend-swatch.margin {
-    border-color: rgb(var(--line-color));
+    border-color: var(--ink);
+    background: radial-gradient(var(--ink) 1px, transparent 1px) 0 0 / 4px 4px;
 }
 
 .legend-swatch.printable {
-    border-color: rgb(var(--printable-color));
-    background-color: rgba(var(--printable-color), 0.25);
+    border-color: var(--ink);
+    background:
+        repeating-linear-gradient(
+            45deg,
+            var(--ink) 0,
+            var(--ink) 2px,
+            transparent 2px,
+            transparent 4px
+        ),
+        repeating-linear-gradient(
+            -45deg,
+            var(--ink) 0,
+            var(--ink) 2px,
+            transparent 2px,
+            transparent 4px
+        );
 }
 
 .legend-line {
@@ -366,7 +388,7 @@ tbody tr:nth-child(even) {
 
 .legend-line.score {
     border-top-style: dashed;
-    border-color: rgb(var(--line-color));
+    border-color: var(--ink);
 }
 
 .visualizer-column.card {

--- a/styles/components.css
+++ b/styles/components.css
@@ -358,7 +358,7 @@ tbody tr:nth-child(even) {
 
 .legend-swatch.margin {
     border-color: var(--ink);
-    background: radial-gradient(var(--ink) 1px, transparent 1px) 0 0 / 4px 4px;
+    background: radial-gradient(var(--ink) 2px, transparent 2px) 0 0 / 6px 6px;
 }
 
 .legend-swatch.printable {

--- a/styles/components.css
+++ b/styles/components.css
@@ -347,15 +347,23 @@ tbody tr:nth-child(even) {
 
 .legend-swatch.doc {
     border-color: var(--ink);
+    /* Use a high-contrast color for stripes instead of transparent */
     background: repeating-linear-gradient(
         0deg,
         var(--ink) 0,
         var(--ink) 2px,
-        transparent 2px,
-        transparent 4px
+        var(--card) 2px,
+        var(--card) 4px
     );
 }
 
+/* Fallback for users who prefer increased contrast */
+@media (prefers-contrast: more) {
+    .legend-swatch.doc {
+        background: var(--ink);
+        border-color: var(--card);
+    }
+}
 .legend-swatch.margin {
     border-color: var(--ink);
     background: radial-gradient(var(--ink) 2px, transparent 2px) 0 0 / 6px 6px;


### PR DESCRIPTION
## Summary
- Differentiate legend items with pattern-based swatches and dashed score glyphs
- Clarify legend labels for document outline and dashed score lines

## Testing
- `for f in tests/*.test.js; do node "$f"; done`


------
https://chatgpt.com/codex/tasks/task_e_68ae81882c808324991c81fdadbf363f