### PR TITLE
Default to system dark mode and smooth theme transitions

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,15 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Kev's Bitchin' Print Calculator</title>
+    <script>
+        (function() {
+            const savedTheme = localStorage.getItem('theme');
+            const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+            if (savedTheme === 'dark' || (!savedTheme && prefersDark)) {
+                document.documentElement.setAttribute('data-theme', 'dark');
+            }
+        })();
+    </script>
     <link rel="stylesheet" href="styles/base.css">
     <link rel="stylesheet" href="styles/layout.css">
     <link rel="stylesheet" href="styles/components.css">

--- a/src/ui/events.js
+++ b/src/ui/events.js
@@ -119,9 +119,13 @@ function rotateSize(type, elements, shouldCalculate = true) {
 
 export function initTheme(elements) {
     const savedTheme = localStorage.getItem('theme');
-    if (savedTheme === 'dark') {
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    if (savedTheme === 'dark' || (!savedTheme && prefersDark)) {
         document.documentElement.setAttribute('data-theme', 'dark');
         elements.themeToggle.checked = true;
+    } else {
+        document.documentElement.removeAttribute('data-theme');
+        elements.themeToggle.checked = false;
     }
 }
 

--- a/styles/base.css
+++ b/styles/base.css
@@ -49,6 +49,7 @@ body {
     line-height: 1.45;
     font-size: 16px;
     color: var(--ink);
+    transition: background-color 0.2s, color 0.2s;
 }
 
 /* Typography */
@@ -67,6 +68,7 @@ h1 {
     position: sticky;
     top: 0;
     z-index: 10;
+    transition: background-color 0.2s, color 0.2s, border-color 0.2s;
 }
 
 h2 {

--- a/styles/components.css
+++ b/styles/components.css
@@ -5,6 +5,7 @@
     border: 1px solid var(--border);
     background-color: var(--card);
     box-shadow: var(--shadow-md);
+    transition: background-color 0.2s, color 0.2s, border-color 0.2s;
 }
 
 .data-card {
@@ -141,6 +142,7 @@
     background-color: var(--button-bg);
     color: var(--button-ink);
     font: inherit;
+    transition: background-color 0.2s, color 0.2s, border-color 0.2s;
 }
 
 
@@ -202,6 +204,9 @@ select {
     padding: 8px;
     box-sizing: border-box;
     background-color: var(--card);
+    color: var(--ink);
+    border: 1px solid var(--border);
+    transition: background-color 0.2s, color 0.2s, border-color 0.2s;
 }
 
 .form-grid {
@@ -296,6 +301,7 @@ td {
     border: 1px solid var(--border);
     padding: 8px;
     font-size: 14px;
+    transition: background-color 0.2s, color 0.2s, border-color 0.2s;
 }
 
 th {

--- a/styles/themes/dark.css
+++ b/styles/themes/dark.css
@@ -15,3 +15,30 @@
     --score-color: var(--printable-color);
     --line-color: 255, 255, 255;
 }
+
+[data-theme="dark"] ::selection {
+    background: var(--blue);
+    color: var(--card);
+}
+
+[data-theme="dark"] {
+    scrollbar-color: var(--border) var(--card);
+}
+
+[data-theme="dark"] ::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+}
+
+[data-theme="dark"] ::-webkit-scrollbar-track {
+    background: var(--card);
+}
+
+[data-theme="dark"] ::-webkit-scrollbar-thumb {
+    background: var(--border);
+    border-radius: 4px;
+}
+
+[data-theme="dark"] ::-webkit-scrollbar-thumb:hover {
+    background: var(--blue);
+}


### PR DESCRIPTION
## Summary
- Respect OS color scheme preference with early theme initialization
- Smooth theme toggling with background/color transitions
- Polish dark theme scrollbars and text selection

## Testing
- `for f in tests/*.test.js; do node "$f"; done`


------
https://chatgpt.com/codex/tasks/task_e_68ae83dfa92883248c8a117a45f12dac