### PR TITLE
Add PDF print button

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,9 @@
             <!-- Site title and mode toggles -->
             <!-- TODO: Accessibility review and responsive tweaks -->
             <h1>Kev's Bitchin' Print Calculator</h1>
-            <div class="menu-bar" id="menuBar"></div>
+            <div class="menu-bar" id="menuBar">
+                <button id="printButton" class="btn btn-secondary">Print PDF</button>
+            </div>
         </header>
 
 
@@ -121,6 +123,9 @@
     <!-- ===== Closing Scripts ===== -->
     <!-- Load application modules -->
     <!-- TODO: Bundle and defer non-critical scripts -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
+    <script type="module" src="src/ui/initPrintButton.js"></script>
     <script type="module" src="src/ui/initToggles.js"></script>
     <script type="module" src="src/ui/renderLegendOptions.js"></script>
     <script type="module" src="app.js"></script>

--- a/src/ui/initPrintButton.js
+++ b/src/ui/initPrintButton.js
@@ -1,0 +1,33 @@
+import { createPrintLayout } from './printLayout.js';
+
+const printButton = document.getElementById('printButton');
+
+// Generates a two-page PDF:
+//  • Page 1: layout visualizer
+//  • Page 2: data cards stacked vertically
+// Pages are sized for a 12x18 inch sheet in landscape orientation
+// with a half‑inch margin on all sides.
+
+printButton.addEventListener('click', async () => {
+    const visualizer = document.querySelector('.visualizer-column');
+    const cards = Array.from(document.querySelectorAll('.data-card'));
+    const { container, pages } = createPrintLayout(visualizer, cards);
+    document.body.appendChild(container);
+
+    const { jsPDF } = window.jspdf;
+    const pdf = new jsPDF({ orientation: 'landscape', unit: 'in', format: [18, 12] });
+
+    const margin = 0.5;
+    const pageWidth = 18 - margin * 2;
+
+    for (let i = 0; i < pages.length; i++) {
+        const canvas = await html2canvas(pages[i], { scale: 2 });
+        const image = canvas.toDataURL('image/png');
+        const height = (canvas.height / canvas.width) * pageWidth;
+        if (i > 0) pdf.addPage([18, 12], 'landscape');
+        pdf.addImage(image, 'PNG', margin, margin, pageWidth, height);
+    }
+
+    document.body.removeChild(container);
+    pdf.save('layout.pdf');
+});

--- a/src/ui/printLayout.js
+++ b/src/ui/printLayout.js
@@ -1,0 +1,53 @@
+// printLayout.js
+//
+// Builds an off-screen DOM layout representing a two-page, 12x18 inch document.
+// Page 1 holds the layout visualizer, page 2 stacks all data cards.
+// The resulting structure can be fed to html2canvas/jsPDF for PDF generation.
+
+/**
+ * Create a two-page print layout.
+ * @param {HTMLElement} visualizer - element containing the layout visualizer
+ * @param {HTMLElement[]} cards - array of data card elements
+ * @returns {{container: HTMLElement, pages: HTMLElement[]}}
+ */
+export function createPrintLayout(visualizer, cards) {
+    // Wrapper is positioned off-screen so it's not visible to the user
+    const container = document.createElement('div');
+    container.className = 'print-layout';
+    container.style.position = 'absolute';
+    container.style.left = '-9999px';
+
+    // --- Page 1: Visualizer ---
+    const page1 = createPage('visualizer-page');
+    page1.querySelector('.page-content').appendChild(visualizer.cloneNode(true));
+
+    // --- Page 2: Cards ---
+    const page2 = createPage('cards-page');
+    const content = page2.querySelector('.page-content');
+    cards.forEach(card => content.appendChild(card.cloneNode(true)));
+
+    container.append(page1, page2);
+    return { container, pages: [page1, page2] };
+}
+
+/**
+ * Helper to create a single page sized for 12x18 with half-inch margins.
+ * @param {string} className additional class to identify the page type
+ */
+function createPage(className = '') {
+    const page = document.createElement('section');
+    page.className = `print-page ${className}`.trim();
+    page.style.width = '18in';
+    page.style.height = '12in';
+    page.style.padding = '0.5in';
+    page.style.boxSizing = 'border-box';
+
+    // Inner container that respects the margin area
+    const content = document.createElement('div');
+    content.className = 'page-content';
+    content.style.width = '100%';
+    content.style.height = '100%';
+    page.appendChild(content);
+
+    return page;
+}


### PR DESCRIPTION
## Summary
- add header button to generate 12x18 PDF export
- capture visualizer and cards on separate pages using html2canvas and jsPDF
- build two-page HTML print layout module for PDF rendering

## Testing
- `for f in tests/*.test.js; do node $f; done`


------
https://chatgpt.com/codex/tasks/task_e_68afd71b85d48324a985d1fd0b79216a