### PR TITLE
refactor: consolidate default size handling

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,7 +1,7 @@
 import './src/ui/sectionFactory.js';
 import { elements } from './src/ui/elements.js';
 import { registerEventListeners, initTheme } from './src/ui/events.js';
-import { setDefaultValues, selectDefaultSizes, calculateLayout } from './src/layout/layoutController.js';
+import { selectDefaultSizes, calculateLayout } from './src/layout/layoutController.js';
 import { createSizeButtons } from './src/ui/buttonCreation.js';
 import { INCH_SIZE_OPTIONS } from './src/config/sizeOptions.js';
 
@@ -13,9 +13,8 @@ function init() {
         gutterButtons: elements.gutterButtons,
         marginButtons: elements.marginButtons
     }, INCH_SIZE_OPTIONS);
-    setDefaultValues(elements);
-    selectDefaultSizes(elements);
     registerEventListeners(elements);
+    selectDefaultSizes(elements);
     calculateLayout(elements);
 }
 

--- a/src/config/sizeOptions.js
+++ b/src/config/sizeOptions.js
@@ -3,7 +3,7 @@
 // ===== Constants =====
 export const INCH_SIZE_OPTIONS = {
     sheet: [
-        { width: 12, length: 18, name: "Tabloid Extra" },
+        { width: 12, length: 18, name: "Tabloid Extra", default: true },
         { width: 13, length: 19, name: "Super B" },
         { width: 8.5, length: 11, name: "Letter" },
         { width: 9, length: 12, name: "Letter Plus" },
@@ -13,7 +13,7 @@ export const INCH_SIZE_OPTIONS = {
         { width: 14.66, length: 25, name: "Awful Oversize" }
     ],
     doc: [
-        { width: 3.5, length: 4, name: "Folded Business Card" },
+        { width: 3.5, length: 4, name: "Folded Business Card", default: true },
         { width: 4.25, length: 11, name: "Door Hanger" },
         { width: 4.25, length: 5.5, name: "Quarter Letter" },
         { width: 5, length: 7, name: "5x7" },
@@ -22,14 +22,14 @@ export const INCH_SIZE_OPTIONS = {
         { width: 4, length: 6, name: "Chipotle" }
     ],
     gutter: [
-        { width: 0.125, length: 0.125, name: "1/8" },
+        { width: 0.125, length: 0.125, name: "1/8", default: true },
         { width: 0.25, length: 0.25, name: "1/4" },
         { width: 0, length: 0, name: "No Gutter" },
         { width: 0.3125, length: 0.17, name: "Duplo 25 UP" }
     ],
     margin: [
         { width: 0.0625, length: 0.0625, name: "1/16" },
-        { width: 0.25, length: 0.25, name: "1/4" },
+        { width: 0.25, length: 0.25, name: "1/4", default: true },
         { width: 0.5, length: 0.5, name: "1/2" },
         { width: 0, length: 0, name: "No Margin" },
         { width: 0.125, length: 0.125, name: "1/8" }
@@ -39,7 +39,7 @@ export const INCH_SIZE_OPTIONS = {
 // Metric equivalents in millimeters
 export const MM_SIZE_OPTIONS = {
     sheet: [
-        { width: 305, length: 457, name: "Tabloid Extra" },
+        { width: 305, length: 457, name: "Tabloid Extra", default: true },
         { width: 330, length: 483, name: "Super B" },
         { width: 216, length: 279, name: "Letter" },
         { width: 229, length: 305, name: "Letter Plus" },
@@ -49,7 +49,7 @@ export const MM_SIZE_OPTIONS = {
         { width: 372, length: 635, name: "Awful Oversize" }
     ],
     doc: [
-        { width: 89, length: 102, name: "Folded Business Card" },
+        { width: 89, length: 102, name: "Folded Business Card", default: true },
         { width: 108, length: 279, name: "Door Hanger" },
         { width: 108, length: 140, name: "Quarter Letter" },
         { width: 127, length: 178, name: "5x7" },
@@ -58,14 +58,14 @@ export const MM_SIZE_OPTIONS = {
         { width: 102, length: 152, name: "Chipotle" }
     ],
     gutter: [
-        { width: 3, length: 3, name: "1/8" },
+        { width: 3, length: 3, name: "1/8", default: true },
         { width: 6, length: 6, name: "1/4" },
         { width: 0, length: 0, name: "No Gutter" },
         { width: 8, length: 4, name: "Duplo 25 UP" }
     ],
     margin: [
         { width: 2, length: 2, name: "1/16" },
-        { width: 6, length: 6, name: "1/4" },
+        { width: 6, length: 6, name: "1/4", default: true },
         { width: 13, length: 13, name: "1/2" },
         { width: 0, length: 0, name: "No Margin" },
         { width: 3, length: 3, name: "1/8" }

--- a/src/layout/layoutController.js
+++ b/src/layout/layoutController.js
@@ -161,53 +161,13 @@ export function updateLayoutInfo(layout, elements, config = null) {
     elements.wasteLegend.textContent = `Waste: ${waste}%`;
 }
 
-export function setDefaultValues(elements, isMetric = false) {
-    if (isMetric) {
-        elements.sheetWidth.value = "305";
-        elements.sheetLength.value = "457";
-        elements.docWidth.value = "89";
-        elements.docLength.value = "102";
-        elements.gutterWidth.value = "3";
-        elements.gutterLength.value = "3";
-        elements.marginWidth.value = "6";
-        elements.marginLength.value = "6";
-    } else {
-        elements.sheetWidth.value = "12.0";
-        elements.sheetLength.value = "18.0";
-        elements.docWidth.value = "3.5";
-        elements.docLength.value = "4.0";
-        elements.gutterWidth.value = "0.125";
-        elements.gutterLength.value = "0.125";
-        elements.marginWidth.value = "0.25";
-        elements.marginLength.value = "0.25";
-    }
-}
-
-export function selectDefaultSizes(elements, isMetric = false) {
-    const defaultSelections = isMetric
-        ? {
-              sheet: { width: 305, length: 457 },
-              doc: { width: 89, length: 102 },
-              gutter: { width: 3, length: 3 },
-              margin: { width: 6, length: 6 }
-          }
-        : {
-              sheet: { width: 12, length: 18 },
-              doc: { width: 3.5, length: 4 },
-              gutter: { width: 0.125, length: 0.125 },
-              margin: { width: 0.25, length: 0.25 }
-          };
-
-    Object.entries(defaultSelections).forEach(([type, { width, length }]) => {
+export function selectDefaultSizes(elements) {
+    ['sheet', 'doc', 'gutter', 'margin'].forEach(type => {
         const container = elements[`${type}Buttons`];
-        const button = Array.from(container.children).find(btn =>
-            parseFloat(btn.dataset.width) === width && parseFloat(btn.dataset.length) === length
-        );
+        if (!container) return;
+        const button = Array.from(container.children).find(btn => btn.dataset.default === 'true');
         if (button) {
             button.click();
-        } else {
-            elements[`${type}Width`].value = width;
-            elements[`${type}Length`].value = length;
         }
     });
 }

--- a/src/ui/buttonCreation.js
+++ b/src/ui/buttonCreation.js
@@ -11,6 +11,9 @@ export function createButtonsForType(type, container, SIZE_OPTIONS) {
         button.textContent = `${option.width} x ${option.length}`;
         button.dataset.width = option.width;
         button.dataset.length = option.length;
+        if (option.default) {
+            button.dataset.default = 'true';
+        }
         container.appendChild(button);
     });
 

--- a/src/ui/metricToggle.js
+++ b/src/ui/metricToggle.js
@@ -1,6 +1,6 @@
 import { createSizeButtons } from './buttonCreation.js';
 import { INCH_SIZE_OPTIONS, MM_SIZE_OPTIONS } from '../config/sizeOptions.js';
-import { setDefaultValues, selectDefaultSizes, calculateLayout } from '../layout/layoutController.js';
+import { selectDefaultSizes, calculateLayout } from '../layout/layoutController.js';
 import { qs } from '../dom/dom.js';
 
 function updateSteps(elements, isMetric) {
@@ -42,8 +42,7 @@ export function toggleMetricMode(elements) {
         marginButtons: elements.marginButtons
     }, options);
 
-    setDefaultValues(elements, isMetric);
-    selectDefaultSizes(elements, isMetric);
+    selectDefaultSizes(elements);
     updateUnitLabels(isMetric);
     updateSteps(elements, isMetric);
     calculateLayout(elements);


### PR DESCRIPTION
## Summary
- remove redundant default value assignments
- mark default size options in config
- auto-select defaults via data attributes

## Testing
- `for f in tests/*.test.js; do echo running $f; node $f; done`

------
https://chatgpt.com/codex/tasks/task_e_68b12532f5c08324b6500d2c9a66af1c