### PR TITLE
Refine document label rendering

### DIFF
--- a/src/render/drawDocumentLabels.js
+++ b/src/render/drawDocumentLabels.js
@@ -1,23 +1,41 @@
-export function drawDocumentLabels(ctx, layout, scale, offsetX, offsetY, options = {}) {
+// Render numeric labels at the center of each document in the layout grid
+export function drawDocumentLabels(
+    ctx,
+    pageLayout,
+    scale,
+    xOffset,
+    yOffset,
+    options = {}
+) {
     const { showDocNumbers = true, colors } = options;
+
+    // Exit early when labels are disabled
     if (!showDocNumbers) {
         return;
     }
 
-    // Set font size relative to document size 
+    // Configure text style for the labels
     ctx.font = `${Math.round(1.5 * scale)}px Arial`;
-    ctx.fillStyle = (colors && colors.label) ? colors.label : '#000';
+    ctx.fillStyle = colors?.label ?? '#000';
     ctx.textAlign = 'center';
     ctx.textBaseline = 'middle';
 
-    let docNumber = 1;
+    // Iterate over each document slot in the layout grid
+    for (let columnIndex = 0; columnIndex < pageLayout.docsAcross; columnIndex++) {
+        for (let rowIndex = 0; rowIndex < pageLayout.docsDown; rowIndex++) {
+            // Compute the center point of the current document
+            const x =
+                xOffset +
+                (pageLayout.leftMargin + (columnIndex + 0.5) * (pageLayout.docWidth + pageLayout.gutterWidth)) * scale;
+            const y =
+                yOffset +
+                (pageLayout.topMargin + (rowIndex + 0.5) * (pageLayout.docLength + pageLayout.gutterLength)) * scale;
 
-    for (let i = 0; i < layout.docsAcross; i++) {
-        for (let j = 0; j < layout.docsDown; j++) {
-            const x = offsetX + (layout.leftMargin + (i + 0.5) * (layout.docWidth + layout.gutterWidth)) * scale;
-            const y = offsetY + (layout.topMargin + (j + 0.5) * (layout.docLength + layout.gutterLength)) * scale;
-            ctx.fillText(docNumber.toString(), x, y);
-            docNumber++;
+            // Determine the document number based on its row and column
+            const documentNumber = rowIndex * pageLayout.docsAcross + columnIndex + 1;
+
+            // Draw the document number in the center of the document
+            ctx.fillText(documentNumber.toString(), x, y);
         }
     }
 }

--- a/visualizer.js
+++ b/visualizer.js
@@ -51,8 +51,9 @@ export function drawLayout(canvas, layout, scorePositions = [], marginData = {},
     const baseScale = Math.min(width / layout.sheetWidth, height / layout.sheetLength) * 0.9;
     const scale = baseScale * zoom;
 
-    const offsetX = (canvas.width - layout.sheetWidth * scale) / 2;
-    const offsetY = (canvas.height - layout.sheetLength * scale) / 2;
+    // Center the sheet within the canvas
+    const xOffset = (canvas.width - layout.sheetWidth * scale) / 2;
+    const yOffset = (canvas.height - layout.sheetLength * scale) / 2;
 
     ctx.clearRect(0, 0, canvas.width, canvas.height);
     
@@ -61,11 +62,11 @@ export function drawLayout(canvas, layout, scorePositions = [], marginData = {},
     ctx.translate(0.5, 0.5);
 
     // Draw layout components
-    drawSheet(ctx, layout, scale, offsetX, offsetY, helperOptions);
-    drawPrintableArea(ctx, layout, scale, offsetX, offsetY, helperOptions);
-    drawDocuments(ctx, layout, scale, offsetX, offsetY, helperOptions);
-    drawMargins(ctx, layout, scale, offsetX, offsetY, helperOptions);
-    drawScoreLines(ctx, layout, scale, offsetX, offsetY, helperOptions);
+    drawSheet(ctx, layout, scale, xOffset, yOffset, helperOptions);
+    drawPrintableArea(ctx, layout, scale, xOffset, yOffset, helperOptions);
+    drawDocuments(ctx, layout, scale, xOffset, yOffset, helperOptions);
+    drawMargins(ctx, layout, scale, xOffset, yOffset, helperOptions);
+    drawScoreLines(ctx, layout, scale, xOffset, yOffset, helperOptions);
     ctx.translate(-0.5, -0.5);
-    drawDocumentLabels(ctx, layout, scale, offsetX, offsetY, helperOptions);
+    drawDocumentLabels(ctx, layout, scale, xOffset, yOffset, helperOptions);
 }


### PR DESCRIPTION
## Summary
- clarify document labeling logic with comments and descriptive names
- compute label numbers directly from row and column indexes
- adopt `xOffset`/`yOffset` naming when centering layout in the visualizer

## Testing
- `node tests/calculateAdaptiveScale.test.js`
- `node tests/drawLayout.test.js`
- `node tests/scoreLines.test.js`
- `node tests/calculations.test.js`
- `node tests/optimalLayout.test.js`
- `node tests/scoring.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b2556c21508324aa6f50fdab2fe265