### PR TITLE
Refactor scoring logic and controller

### DIFF
--- a/src/scoring/scoreController.js
+++ b/src/scoring/scoreController.js
@@ -1,40 +1,40 @@
-import { calculateScorePositions, FOLD_ALLOWANCE_INCH, FOLD_ALLOWANCE_MM } from './scoring.js';
+import { computeScorePositions, FOLD_ALLOWANCE_INCH, FOLD_ALLOWANCE_MM } from './scoring.js';
 import { renderScorePositions } from '../ui/display.js';
 import { calculateLayoutDetails, drawLayoutWrapper } from '../layout/layoutController.js';
 import { qs } from '../dom/dom.js';
 
-let lastScorePositions = [];
+let cachedScorePositions = [];
 
-export function calculateScores(elements) {
+export function calculateAndRenderScores(elements) {
     const foldType = qs('#foldType', elements.scoreControls).value;
     const layout = calculateLayoutDetails(elements);
 
-    let custom = [];
+    let customOffsets = [];
     if (foldType === 'custom') {
-        custom = qs('#customScores', elements.scoreControls)
+        customOffsets = qs('#customScores', elements.scoreControls)
             .value.split(',')
             .map(n => parseFloat(n.trim()))
             .filter(n => !isNaN(n));
     }
 
-    const allowance = elements.metricToggle.checked ? FOLD_ALLOWANCE_MM : FOLD_ALLOWANCE_INCH;
-    const scorePositions = calculateScorePositions(layout, foldType, custom, allowance);
-    lastScorePositions = scorePositions;
+    const foldAllowance = elements.metricToggle.checked ? FOLD_ALLOWANCE_MM : FOLD_ALLOWANCE_INCH;
+    const scoreLines = computeScorePositions(layout, foldType, customOffsets, foldAllowance);
+    cachedScorePositions = scoreLines;
 
-    drawLayoutWrapper(layout, elements.showScores.checked ? scorePositions : [], elements);
-    displayScorePositions(scorePositions, elements);
+    drawLayoutWrapper(layout, elements.showScores.checked ? scoreLines : [], elements);
+    updateScorePositionDisplay(scoreLines, elements);
 }
 
-export function displayScorePositions(scorePositions, elements) {
+export function updateScorePositionDisplay(scoreLines, elements) {
     const unit = elements.metricToggle.checked ? 'mm' : 'inches';
-    renderScorePositions(scorePositions, elements.scorePositions, unit);
+    renderScorePositions(scoreLines, elements.scorePositions, unit);
 }
 
-export function getLastScorePositions() {
-    return lastScorePositions;
+export function getCachedScorePositions() {
+    return cachedScorePositions;
 }
 
-export function clearScoreData(elements) {
-    lastScorePositions = [];
-    displayScorePositions([], elements);
+export function resetScorePositions(elements) {
+    cachedScorePositions = [];
+    updateScorePositionDisplay([], elements);
 }

--- a/src/ui/events.js
+++ b/src/ui/events.js
@@ -1,5 +1,5 @@
 import { calculateLayout, calculateLayoutDetails, drawLayoutWrapper, zoomIn, zoomOut, resetZoom, retrieveOptimalConfig } from '../layout/layoutController.js';
-import { calculateScores, getLastScorePositions, clearScoreData } from '../scoring/scoreController.js';
+import { calculateAndRenderScores, getCachedScorePositions, resetScorePositions } from '../scoring/scoreController.js';
 import { toggleMetricMode } from './metricToggle.js';
 import { byId, qsa, classes, visibility } from '../dom/dom.js';
 
@@ -17,25 +17,25 @@ export function registerEventListeners(elements) {
                 classes.add(customMarginButton, 'active');
             }
             visibility.show(elements.marginInputs);
-            calculateLayout(elements, getLastScorePositions(), () => clearScoreData(elements));
+            calculateLayout(elements, getCachedScorePositions(), () => resetScorePositions(elements));
         });
     });
 
     elements.fitSheetButton.addEventListener('click', () => {
         resetZoom();
-        calculateLayout(elements, getLastScorePositions(), () => clearScoreData(elements));
+        calculateLayout(elements, getCachedScorePositions(), () => resetScorePositions(elements));
     });
     elements.zoomOutButton.addEventListener('click', () => {
         zoomOut();
-        calculateLayout(elements, getLastScorePositions(), () => clearScoreData(elements));
+        calculateLayout(elements, getCachedScorePositions(), () => resetScorePositions(elements));
     });
     elements.zoomInButton.addEventListener('click', () => {
         zoomIn();
-        calculateLayout(elements, getLastScorePositions(), () => clearScoreData(elements));
+        calculateLayout(elements, getCachedScorePositions(), () => resetScorePositions(elements));
     });
     elements.resetViewButton.addEventListener('click', () => {
         resetZoom();
-        calculateLayout(elements, getLastScorePositions(), () => clearScoreData(elements));
+        calculateLayout(elements, getCachedScorePositions(), () => resetScorePositions(elements));
     });
     elements.rotateDocsButton.addEventListener('click', () => rotateSize('doc', elements));
     elements.rotateSheetButton.addEventListener('click', () => rotateSize('sheet', elements));
@@ -54,7 +54,7 @@ export function registerEventListeners(elements) {
         }
         elements.sheetWidth.value = config.sheetWidth;
         elements.sheetLength.value = config.sheetLength;
-        calculateLayout(elements, getLastScorePositions(), () => clearScoreData(elements));
+        calculateLayout(elements, getCachedScorePositions(), () => resetScorePositions(elements));
         elements.optimalLayoutButton.classList.add('hidden');
     });
 
@@ -62,16 +62,16 @@ export function registerEventListeners(elements) {
 
     const inputIds = ['sheetWidth', 'sheetLength', 'docWidth', 'docLength', 'gutterWidth', 'gutterLength', 'marginWidth', 'marginLength'];
     inputIds.forEach(id => {
-        elements[id].addEventListener('input', () => calculateLayout(elements, getLastScorePositions(), () => clearScoreData(elements)));
+        elements[id].addEventListener('input', () => calculateLayout(elements, getCachedScorePositions(), () => resetScorePositions(elements)));
     });
 
-    elements.calculateScoresButton.addEventListener('click', () => calculateScores(elements));
+    elements.calculateScoresButton.addEventListener('click', () => calculateAndRenderScores(elements));
     elements.foldType.addEventListener('change', () => toggleCustomInputs(elements));
 
     ['showScores', 'showDocNumbers', 'showPrintableArea', 'showMargins'].forEach(id => {
         elements[id].addEventListener('change', () => {
             const layout = calculateLayoutDetails(elements);
-            drawLayoutWrapper(layout, elements.showScores.checked ? getLastScorePositions() : [], elements);
+            drawLayoutWrapper(layout, elements.showScores.checked ? getCachedScorePositions() : [], elements);
         });
     });
 
@@ -103,7 +103,7 @@ function handleSizeButtonClick(event, elements) {
         }
     }
 
-    calculateLayout(elements, getLastScorePositions(), () => clearScoreData(elements));
+    calculateLayout(elements, getCachedScorePositions(), () => resetScorePositions(elements));
 }
 
 function rotateSize(type, elements, shouldCalculate = true) {
@@ -114,7 +114,7 @@ function rotateSize(type, elements, shouldCalculate = true) {
         [elements.marginWidth.value, elements.marginLength.value] = [elements.marginLength.value, elements.marginWidth.value];
     }
     if (shouldCalculate) {
-        calculateLayout(elements, getLastScorePositions(), () => clearScoreData(elements));
+        calculateLayout(elements, getCachedScorePositions(), () => resetScorePositions(elements));
     }
 }
 
@@ -140,7 +140,7 @@ function toggleTheme(elements) {
         localStorage.setItem('theme', 'light');
     }
     const layout = calculateLayoutDetails(elements);
-    drawLayoutWrapper(layout, elements.showScores.checked ? getLastScorePositions() : [], elements);
+    drawLayoutWrapper(layout, elements.showScores.checked ? getCachedScorePositions() : [], elements);
 }
 
 function toggleCustomInputs(elements) {

--- a/tests/scoreLines.test.js
+++ b/tests/scoreLines.test.js
@@ -5,7 +5,7 @@ const assert = require('assert');
 
 (async () => {
   const { calculateLayoutDetails } = await import('../src/layout/calculations.js');
-  const { calculateScorePositions } = await import('../src/scoring/scoring.js');
+  const { computeScorePositions } = await import('../src/scoring/scoring.js');
   const { drawLayout } = await import('../visualizer.js');
 
   const layout = calculateLayoutDetails({
@@ -17,7 +17,7 @@ const assert = require('assert');
     gutterLength: 0.25
   });
 
-  const scorePositions = calculateScorePositions(layout, 'bifold');
+  const scorePositions = computeScorePositions(layout, 'bifold');
 
   const ctx = {
     moveToCalls: [],

--- a/tests/scoring.test.js
+++ b/tests/scoring.test.js
@@ -2,7 +2,7 @@ const assert = require('assert');
 
 (async () => {
   const { calculateLayoutDetails } = await import('../src/layout/calculations.js');
-  const { calculateScorePositions } = await import('../src/scoring/scoring.js');
+  const { computeScorePositions } = await import('../src/scoring/scoring.js');
 
   const layout = calculateLayoutDetails({
     sheetWidth: 12,
@@ -14,41 +14,41 @@ const assert = require('assert');
   });
 
   // Verify bifold score positions
-  const bifoldScores = calculateScorePositions(layout, 'bifold');
+  const bifoldScores = computeScorePositions(layout, 'bifold');
   assert.strictEqual(bifoldScores.length, 4, 'Bifold score count incorrect');
   assert.strictEqual(bifoldScores[0].y, 2.625, 'First bifold score incorrect');
 
   // Verify trifold score positions
-  const trifoldScores = calculateScorePositions(layout, 'trifold');
+  const trifoldScores = computeScorePositions(layout, 'trifold');
   assert.strictEqual(trifoldScores.length, 8, 'Trifold score count incorrect');
   assert.ok(Math.abs(trifoldScores[0].y - 1.9583333333333333) < 1e-9, 'First trifold score incorrect');
 
   // Verify gatefold score positions
-  const gatefoldScores = calculateScorePositions(layout, 'gatefold');
+  const gatefoldScores = computeScorePositions(layout, 'gatefold');
   assert.strictEqual(gatefoldScores.length, 8, 'Gatefold score count incorrect');
   assert.ok(Math.abs(gatefoldScores[0].y - 1.625) < 1e-9, 'First gatefold score incorrect');
 
   // Verify allowance adjustment
-  const trifoldCustomAllowance = calculateScorePositions(layout, 'trifold', [], 0.1);
+  const trifoldCustomAllowance = computeScorePositions(layout, 'trifold', [], 0.1);
   assert.ok(Math.abs(trifoldCustomAllowance[1].y - 3.191666666666666) < 1e-9, 'Trifold custom allowance incorrect');
 
-  const gatefoldCustomAllowance = calculateScorePositions(layout, 'gatefold', [], 0.1);
+  const gatefoldCustomAllowance = computeScorePositions(layout, 'gatefold', [], 0.1);
   assert.ok(Math.abs(gatefoldCustomAllowance[1].y - 3.525) < 1e-9, 'Gatefold custom allowance incorrect');
 
   // Verify custom score positions
-  const customScores = calculateScorePositions(layout, 'custom', [1, 2]);
+  const customScores = computeScorePositions(layout, 'custom', [1, 2]);
   assert.strictEqual(customScores.length, 8, 'Custom score count incorrect');
   assert.strictEqual(customScores[0].y, 1.625, 'First custom score incorrect');
 
   // Verify filtering of out-of-range custom positions
-  const filteredCustomScores = calculateScorePositions(layout, 'custom', [-1, 2, 4, 5, 'a']);
+  const filteredCustomScores = computeScorePositions(layout, 'custom', [-1, 2, 4, 5, 'a']);
   assert.strictEqual(filteredCustomScores.length, 8, 'Filtered custom score count incorrect');
   assert.strictEqual(filteredCustomScores[0].y, layout.topMargin + 2, 'Filtered custom first score incorrect');
   assert.strictEqual(filteredCustomScores[1].y, layout.topMargin + 4, 'Filtered custom second score incorrect');
 
   // Verify invalid fold type handling
   assert.throws(
-    () => calculateScorePositions(layout, 'invalid'),
+    () => computeScorePositions(layout, 'invalid'),
     /Unsupported fold type/
   );
 


### PR DESCRIPTION
## Summary
- streamline score calculations with strategy map and descriptive computeScorePositions API
- rename and simplify scoring controller functions with cached positions
- update event handlers and tests for new scoring APIs

## Testing
- `node tests/calculations.test.js`
- `node tests/drawLayout.test.js`
- `node tests/calculateAdaptiveScale.test.js`
- `node tests/optimalLayout.test.js`
- `node tests/scoring.test.js`
- `node tests/scoreLines.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b2572918dc8324af67b61740dfdd9a