### PR TITLE
Fix sheet visual not displaying in visualizer

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,5 +1,6 @@
 import { initSetupPanel } from './src/ui/setupPanel.js';
 import { initOutputPanel } from './src/ui/outputPanel.js';
+import { renderLegendOptions } from './src/ui/renderLegendOptions.js';
 import { elements } from './src/ui/elements.js';
 import { registerEventListeners, initTheme } from './src/ui/events.js';
 import { calculateLayout } from './src/layout/layoutController.js';
@@ -8,9 +9,16 @@ function init() {
     // Initialize theme first
     initTheme(elements);
 
-    // Initialize new UI panels
+    // Initialize new UI panels (creates containers like #visualizerOptions)
     initSetupPanel();
     initOutputPanel();
+
+    // Render legend and visualizer option checkboxes
+    // (must run after initSetupPanel creates #visualizerOptions)
+    renderLegendOptions();
+
+    // Refresh elements cache so dynamically created elements can be found
+    elements.refresh();
 
     // Register event listeners
     registerEventListeners(elements);

--- a/index.html
+++ b/index.html
@@ -102,41 +102,14 @@
 
 
             <!-- ===== Data Column ===== -->
-            <aside class="data-column">
-                <!-- Displays program sequence and scoring options -->
-                <!-- TODO: Expand analytics and improve mobile layout -->
-                <!-- Program Sequence output card -->
-                <section id="programSequence" class="card data-card" role="status" aria-live="polite"></section>
-
-                <!-- Score options card now contains score positions -->
-                <section id="scoreOptions" class="card data-card">
-                    <div class="card-header">
-                        <h2>Scoring</h2>
-                        <button type="button" id="calculateScoresButton" class="btn">Calculate Scores</button>
-                    </div>
-                    <div id="scoreControls" class="form-grid">
-                        <label for="foldType">Score Type:</label>
-                        <select id="foldType">
-                            <option value="bifold">Bifold</option>
-                            <option value="trifold">Trifold</option>
-                            <option value="gatefold">Gatefold</option>
-                            <option value="custom">Custom</option>
-                        </select>
-                        <div id="customScoreInputs" class="hidden">
-                            <label for="customScores">Custom Positions (in, comma-separated)</label>
-                            <input type="text" id="customScores" placeholder="e.g., 2,4.5">
-                        </div>
-                    </div>
-                    <div id="scorePositions" role="status" aria-live="polite"></div>
-                </section>
-            </aside>
+            <!-- Output panel with tabs - populated by initOutputPanel() -->
+            <aside class="data-column"></aside>
         </main>
     </div>
     <!-- ===== Closing Scripts ===== -->
     <!-- Load application modules -->
     <!-- TODO: Bundle and defer non-critical scripts -->
     <script type="module" src="src/ui/initToggles.js"></script>
-    <script type="module" src="src/ui/renderLegendOptions.js"></script>
     <script type="module" src="app.js"></script>
     <script type="module" src="visualizer.js"></script>
 </body>

--- a/src/scoring/scoreController.js
+++ b/src/scoring/scoreController.js
@@ -1,18 +1,17 @@
 import { computeScorePositions, FOLD_ALLOWANCE_INCH, FOLD_ALLOWANCE_MM } from './scoring.js';
 import { renderScorePositions } from '../ui/display.js';
 import { calculateLayoutDetails, drawLayoutWrapper } from '../layout/layoutController.js';
-import { qs } from '../dom/dom.js';
 
 let cachedScorePositions = [];
 
 export function calculateAndRenderScores(elements) {
-    const foldType = qs('#foldType', elements.scoreControls).value;
+    const foldType = elements.foldType.value;
     const layout = calculateLayoutDetails(elements);
 
     let customOffsets = [];
     if (foldType === 'custom') {
-        customOffsets = qs('#customScores', elements.scoreControls)
-            .value.split(',')
+        customOffsets = elements.customScores.value
+            .split(',')
             .map(n => parseFloat(n.trim()))
             .filter(n => !isNaN(n));
     }

--- a/src/ui/renderLegendOptions.js
+++ b/src/ui/renderLegendOptions.js
@@ -53,4 +53,5 @@ export function renderLegendOptions() {
     }
 }
 
-renderLegendOptions();
+// Note: renderLegendOptions() is called from app.js after initSetupPanel()
+// creates the #visualizerOptions container

--- a/styles/visualizer.css
+++ b/styles/visualizer.css
@@ -16,9 +16,11 @@
 /* ===== Canvas Wrapper ===== */
 .canvas-wrapper {
     width: 100%;
+    min-height: 300px;
     max-height: 80vh;
     aspect-ratio: var(--sheet-aspect, 1/1);
     margin-top: var(--space-md);
+    position: relative;
 }
 
 .canvas-wrapper canvas {
@@ -26,6 +28,8 @@
     height: 100%;
     display: block;
     background-color: var(--card);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
 }
 
 #layoutCanvas {


### PR DESCRIPTION
Root cause: renderLegendOptions.js was auto-executing before initSetupPanel() created the #visualizerOptions container, so visualizer checkboxes were never created, causing errors when calculateLayout() tried to access them.

Changes:
- Remove auto-execution from renderLegendOptions.js, call from app.js instead
- Call renderLegendOptions() after initSetupPanel() in correct init sequence
- Add elements.refresh() to clear cache after dynamic elements are created
- Remove duplicate scoring controls from index.html (now in setupPanel.js)
- Remove redundant script tag for renderLegendOptions.js from index.html
- Clean up data-column HTML (now populated by initOutputPanel tabs)
- Fix scoreController.js to use elements directly instead of qs with scoreControls
- Add min-height and border styling to canvas-wrapper for visibility